### PR TITLE
Use multi-stage build for the docker image to reduce size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,37 +1,45 @@
-FROM alpine:latest
+FROM alpine:latest as builder
 
 # Install python3 and development files
-RUN apk add alpine-sdk python3 python3-dev
-RUN apk add linux-headers libffi-dev openssl-dev
+RUN set -eux \
+	&& apk add --no-cache \
+		alpine-sdk \
+		libffi-dev \
+		linux-headers \
+		openssl-dev \
+		python3 \
+		python3-dev
 
 # Install pip
-RUN python3 -m ensurepip
-
-# Doing this makes docker & pip succeed > 20% of the time
-# with really terrible internet... otherwise, it randomly
-# fails...
-# RUN pip3 install pycryptodome
-# RUN pip3 install PyNaCl
-# RUN pip3 install cryptography
-# RUN pip3 install typing-extensions
-# RUN pip3 install colorama
-# RUN pip3 install netifaces==0.10.9
-# RUN pip3 install pygments==2.6.1
-# RUN pip3 install sqlalchemy
-# RUN pip3 install rich
-# RUN pip3 install pytablewriter
-# RUN pip3 install bcrypt
+RUN set -eux \
+	&& python3 -m ensurepip
 
 # Copy pwncat source
 COPY . /pwncat
 
-# Create a working directory
-RUN mkdir /work
-
 # Setup pwncat
-RUN cd /pwncat && python3 setup.py install
+RUN set -eux \
+	&& cd /pwncat \
+	&& python3 setup.py install
+
+# Cleanup
+RUN set -eux \
+	&& find /usr/lib -type f -name '*.pyc' -print0 | xargs -0 -n1 rm -rf || true \
+	&& find /usr/lib -type d -name '__pycache__' -print0 | xargs -0 -n1 rm -rf || true
+
+
+FROM alpine:latest as final
+
+RUN set -eux \
+	&& apk add --no-cache \
+		python3 \
+	&& find /usr/lib -type f -name '*.pyc' -print0 | xargs -0 -n1 rm -rf || true \
+	&& find /usr/lib -type d -name '__pycache__' -print0 | xargs -0 -n1 rm -rf || true \
+	&& mkdir /work
+
+COPY --from=builder /usr/bin/pwncat /usr/bin/pwncat
+COPY --from=builder /usr/lib/python3.8 /usr/lib/python3.8
 
 # Set working directory
 WORKDIR /work
-
 ENTRYPOINT ["/usr/bin/pwncat"]


### PR DESCRIPTION
# Docker multistage build

The intend of this PR is to decrease the docker image size by using a multi-stage build approach.
This eliminates the need to have development packages in the final image.

Additional deletion of `*.pyc` files and `__pycache__` dirs in the Python install layer within the final image save another 20 MBytes.

```bash
REPOSITORY       TAG     IMAGE ID      CREATED         SIZE
pwncat-single    latest  0d79acd717c9  8 minutes ago   415MB    # <-- before this PR
pwncat-multi     latest  0ce4b614686c  9 seconds ago   165MB    # <-- with this PR
```

I went ahead and tested this locally to the best of my knowledge.

The only thing I am currently not sure of is if the **`openssl`** package is required in the final build or not.
It might be for the SSH functionality, but I was not able to figure out how to use this.



## Other considerations

As you're currently using `alpine:latest`, the build with the here suggested changes might break in the future as soon as Python 3.9 will be the default. The line in question is this one then:

```dockerfile
COPY --from=builder /usr/lib/python3.8 /usr/lib/python3.8
```

Alternatively you could use any of the Python/Alpine images as base (for both, builder and final), which are bound to Python 3.8 (not sure if that will increase the file size again)