### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ dependency_links = [
 setup(
     name="pwncat",
     version="0.3.1",
+    python_requires='>=3.8',
     description="A fancy reverse and bind shell handler",
     author="Caleb Stewart",
     url="https://gitlab.com/calebstewart/pwncat",


### PR DESCRIPTION
Watched some youtube clips on this and though I'd try this software
I got an error soon after installing - the error was because `shlex.join` is being used:
https://github.com/calebstewart/pwncat/blob/5f12a129681bbdb7cfaa822aa09610236f42eaba/pwncat/__main__.py#L29
Turns out this requires Python 3.8: 
https://docs.python.org/3/library/shlex.html#shlex.join
I propose to explicitly require Python 3.8 at install time so a more appropriate error is thrown to the user. 
The error I got may be confusing to some people:
```
Traceback (most recent call last):
  File "/home/me/.local/share/virtualenvs/proj-2l1lFwst/bin/pwncat", line 33, in <module>
    sys.exit(load_entry_point('pwncat', 'console_scripts', 'pwncat')())
  File "/home/me/.local/share/virtualenvs/proj-2l1lFwst/src/pwncat/pwncat/__main__.py", line 29, in main
    shlex.join(["connect"] + sys.argv[1:]), prog_name="pwncat"
AttributeError: module 'shlex' has no attribute 'join'
```
Thoughts?