### PR TITLE
Fix protocol parsing

### DIFF
--- a/pwncat/__main__.py
+++ b/pwncat/__main__.py
@@ -130,7 +130,6 @@ def main():
             args.connection_string is not None
             or args.pos_port is not None
             or args.port is not None
-            or args.platform is not None
             or args.listen
             or args.identity is not None
         ):

--- a/pwncat/__main__.py
+++ b/pwncat/__main__.py
@@ -143,11 +143,14 @@ def main():
 
             if args.connection_string:
                 m = connect.Command.CONNECTION_PATTERN.match(args.connection_string)
-                protocol = m.group("protocol")
+                protocol = m.group("protocol").removesuffix("://")
                 user = m.group("user")
                 password = m.group("password")
                 host = m.group("host")
                 port = m.group("port")
+
+            if host is not None and host == "":
+                host = None
 
             if protocol is not None and args.listen:
                 console.log(
@@ -180,7 +183,7 @@ def main():
                     console.log(f"[red]error[/red]: {port}: invalid port number")
                     return
 
-            if protocol != "ssh://" and args.identity is not None:
+            if protocol != "ssh" and args.identity is not None:
                 console.log(
                     f"[red]error[/red]: --identity is only valid for ssh protocols"
                 )

--- a/pwncat/__main__.py
+++ b/pwncat/__main__.py
@@ -143,11 +143,14 @@ def main():
 
             if args.connection_string:
                 m = connect.Command.CONNECTION_PATTERN.match(args.connection_string)
-                protocol = m.group("protocol").removesuffix("://")
+                protocol = m.group("protocol")
                 user = m.group("user")
                 password = m.group("password")
                 host = m.group("host")
                 port = m.group("port")
+
+            if protocol is not None:
+                protocol = protocol.removesuffix("://")
 
             if host is not None and host == "":
                 host = None

--- a/pwncat/channel/ssh.py
+++ b/pwncat/channel/ssh.py
@@ -6,6 +6,7 @@ shell and grabs a PTY. It then wraps the SSH channel in a pwncat channel.
 This module requires a host, user and either a password or identity (key) file.
 An optional port argument is also accepted.
 """
+import os
 import socket
 from typing import Optional
 
@@ -56,7 +57,9 @@ class Ssh(Channel):
             try:
                 # Load the private key for the user
                 if isinstance(identity, str):
-                    key = paramiko.RSAKey.from_private_key_file(identity)
+                    key = paramiko.RSAKey.from_private_key_file(
+                        os.path.expanduser(identity)
+                    )
                 else:
                     key = paramiko.RSAKey.from_private_key(identity)
             except:

--- a/pwncat/channel/ssh.py
+++ b/pwncat/channel/ssh.py
@@ -55,7 +55,10 @@ class Ssh(Channel):
         if identity is not None:
             try:
                 # Load the private key for the user
-                key = paramiko.RSAKey.from_private_key_file(identity)
+                if isinstance(identity, str):
+                    key = paramiko.RSAKey.from_private_key_file(identity)
+                else:
+                    key = paramiko.RSAKey.from_private_key(identity)
             except:
                 password = prompt("RSA Private Key Passphrase: ", is_password=True)
                 try:

--- a/pwncat/commands/connect.py
+++ b/pwncat/commands/connect.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 import re
 
-import pwncat
 from rich import box
 from rich.table import Table
-from pwncat.util import console
 from rich.progress import Progress
+
+import pwncat
+from pwncat.util import console
 from pwncat.modules import ModuleFailed
 from pwncat.commands import Complete, Parameter, CommandDefinition
 
@@ -134,6 +135,12 @@ class Command(CommandDefinition):
             host = m.group("host")
             port = m.group("port")
 
+        if protocol is not None:
+            protocol = protocol.removesuffix("://")
+
+        if host is not None and host == "":
+            host = None
+
         if protocol is not None and args.listen:
             console.log(
                 f"[red]error[/red]: --listen is not compatible with an explicit connection string"
@@ -165,7 +172,7 @@ class Command(CommandDefinition):
                 console.log(f"[red]error[/red]: {port}: invalid port number")
                 return
 
-        if protocol != "ssh://" and args.identity is not None:
+        if protocol != "ssh" and args.identity is not None:
             console.log(f"[red]error[/red]: --identity is only valid for ssh protocols")
             return
 


### PR DESCRIPTION
The `://` suffix wasn't being removed from the protocol and the host was being parsed as an empty string instead of `None` when it wasn't specified. This should fix #107. @cyal1 if you've got the time/attention, I'd appreciate you giving this branch a try and letting me know if this fixes your issue before I merge. Thanks for reporting!