### PR TITLE
Automatically Switch to Bash if Available

### DIFF
--- a/pwncat/platform/linux.py
+++ b/pwncat/platform/linux.py
@@ -549,9 +549,7 @@ class Linux(Platform):
             bash = self._do_which("bash")
             if bash is not None:
                 self.shell = bash
-                self.session.log(
-                    f"[blue]info[/blue]: upgrading from sh to {self.shell}"
-                )
+                self.session.log(f"upgrading from sh to {self.shell}")
                 self.channel.sendline(f"exec {self.shell}".encode("utf-8"))
 
         self.refresh_uid()


### PR DESCRIPTION
When a shell is opened on Linux, we detect if the shell is `sh`. If so, we check for `bash` and attempt to `exec` that shell instead. POSIX compliant shells often don't support any interactivity, which breaks arrow keys and tab completion. If we cannot find `bash`, we print a warning stating that interactive features such as arrow keys will likely not be functional and disable colored prompts.

There's not much else we can do about that, since fundamentally the `sh` shell doesn't support those features. This is the best I can come up with for those incompatibilities. As such, I'm going to say this resolves #100.

I asked @UrfinJuice11 if they could test this, but haven't heard back. I'll give it another day or so, and then merge this branch and move forward.