### PR TITLE
Updated C2 version and Windows.abspath

### DIFF
--- a/test.py
+++ b/test.py
@@ -16,8 +16,8 @@ with pwncat.manager.Manager("data/pwncatrc") as manager:
 
     # Establish a session
     # session = manager.create_session("windows", host="192.168.56.10", port=4444)
-    # session = manager.create_session("windows", host="192.168.122.11", port=4444)
+    session = manager.create_session("windows", host="192.168.122.11", port=4444)
     # session = manager.create_session("linux", host="pwncat-ubuntu", port=4444)
-    session = manager.create_session("linux", host="127.0.0.1", port=4445)
+    # session = manager.create_session("linux", host="127.0.0.1", port=4445)
 
-    session.platform.su("john", "asdfasdfasdf")
+    print(session.platform.Path("./nonexistent.txt").resolve())


### PR DESCRIPTION
I've updated the C2 library, and this branch points to the newest C2 version. This should fix #110. This branch also contains a fix for the `Windows.abspath` method which used to raise a FileNotFoundError for non-existent files. It now correctly resolves relative paths for non-existent files.

@3m0W33D, If you have a few minutes to pull this branch down, I'd appreciate you giving it a try to make sure it solves the issue you were seeing. 