### PR TITLE
Modified File Close Routine

### DIFF
--- a/pwncat/commands/upload.py
+++ b/pwncat/commands/upload.py
@@ -73,6 +73,7 @@ class Command(CommandDefinition):
                 task_id = progress.add_task(
                     "upload", filename=args.destination, total=length, start=False
                 )
+
                 with open(args.source, "rb") as source:
                     with manager.target.platform.open(
                         args.destination, "wb"

--- a/pwncat/data/gtfobins.json
+++ b/pwncat/data/gtfobins.json
@@ -18,7 +18,7 @@
       "args": [
         "of={lfile}",
         "iflag=fullblock",
-        "bs=1"
+        "bs=1048576"
       ]
     }
   ],

--- a/pwncat/platform/linux.py
+++ b/pwncat/platform/linux.py
@@ -460,8 +460,7 @@ class LinuxWriter(BufferedIOBase):
 
         # Indicate EOF
         self.popen.stdin.write(b"\x04")
-        if self.since_newline:
-            self.popen.stdin.write(b"\x04")
+        self.popen.stdin.write(b"\x04")
 
         try:
             # Check for completion


### PR DESCRIPTION
The old logic for exiting the process when writing to a file was flawed. I also increased the block size for `dd` to ensure it reads data as quickly as possible while we upload.

This should fix #117. @3m0W33D if you could give this branch a try and let me know. It worked for me (on Wekor) as seen in the below screenshot. Thanks for reporting!

![image](https://user-images.githubusercontent.com/7529189/121790870-f7aea580-cbb1-11eb-9a1c-455a385c7d30.png)
