### PR TITLE
Checked for SHELL pointing to nologin

### DIFF
--- a/pwncat/platform/linux.py
+++ b/pwncat/platform/linux.py
@@ -547,7 +547,7 @@ class Linux(Platform):
         # This doesn't make sense, but happened for some people (see issue #116)
         if os.path.basename(self.shell) == "nologin":
             self.shell = "/bin/sh"
-            self.channel.sendline(" export SHELL=/bin/sh")
+            self.channel.sendline(b" export SHELL=/bin/sh")
 
         if os.path.basename(self.shell) == "sh":
             # Try to find a better shell

--- a/pwncat/platform/linux.py
+++ b/pwncat/platform/linux.py
@@ -544,6 +544,11 @@ class Linux(Platform):
         if self.shell == "" or self.shell is None:
             self.shell = "/bin/sh"
 
+        # This doesn't make sense, but happened for some people (see issue #116)
+        if os.path.basename(self.shell) == "nologin":
+            self.shell = "/bin/sh"
+            self.channel.sendline(" export SHELL=/bin/sh")
+
         if os.path.basename(self.shell) == "sh":
             # Try to find a better shell
             bash = self._do_which("bash")


### PR DESCRIPTION
I'm not sure why this would happen, but it should fix #116. I just added a check in the setup to see if `SHELL` pointed to `nologin` and attempted to correct it. I tested locally by forcing that environment setup, and it appears to work fine.