### PR TITLE
Add Support for Multiple Shell Types and Removed Colors from `ip` output

### DIFF
--- a/pwncat/modules/linux/enumerate/system/network.py
+++ b/pwncat/modules/linux/enumerate/system/network.py
@@ -31,7 +31,9 @@ class Module(EnumerateModule):
     def enumerate(self, session):
 
         try:
-            output = session.platform.run("ip addr", capture_output=True, text=True)
+            output = session.platform.run(
+                ["ip", "-c=never", "addr"], capture_output=True, text=True
+            )
             if output.stdout:
                 output = (
                     line


### PR DESCRIPTION
The zsh shell uses a different syntax for colored prompts. As such, I've
divided the prompt setup into three different options based on the
basename of the active shell: `sh` (uncolored), `zsh` and `default`.
Other shells can be added to `Linux.PROMPTS` as needed in the future.

Also, add the `-c=never` flag to the `ip` command in `enumerate.system.network`
so that color codes aren't output by the command.

Fixes #126.