### PR TITLE
A few minor fixes

### DIFF
--- a/pwncat/commands/sessions.py
+++ b/pwncat/commands/sessions.py
@@ -73,6 +73,7 @@ class Command(CommandDefinition):
 
         if args.session_id < 0 or args.session_id >= len(manager.sessions):
             console.log(f"[red]error[/red]: {args.session_id}: no such session!")
+            return
 
         session = manager.sessions[args.session_id]
 

--- a/pwncat/platform/linux.py
+++ b/pwncat/platform/linux.py
@@ -488,7 +488,7 @@ class Linux(Platform):
     PATH_TYPE = pathlib.PurePosixPath
     PROMPTS = {
         "sh": """'$(command printf "(remote) $(whoami)@$(hostname):$PWD\\$ ")'""",
-        "zsh": '''"%{$fg[red]%}(remote) %{$fg[yellow]%}%n@%M%{$reset_color%}:%{$fg[cyan]%}%~%{$reset_color%}$%b "''',
+        "zsh": """'%B%F{red}(remote) %B%F{yellow}%n@%M%B%F{reset}:%B%F{cyan}%(6~.%-1~/…/%4~.%5~)%B%(#.%b%F{white}#.%b%F{white}$)%b%F{reset} '""",
         "default": """'$(command printf "\\[\\033[01;31m\\](remote)\\[\\033[0m\\] \\[\\033[01;33m\\]$(whoami)@$(hostname)\\[\\033[0m\\]:\\[\\033[1;36m\\]$PWD\\[\\033[0m\\]\\$ ")'""",
     }
 


### PR DESCRIPTION
## `zsh` prompt color
The current value for setting `PS1` variable for `zsh` isn't working. It is not showing any colors in my case.
This fixes a part of Issue https://github.com/calebstewart/pwncat/issues/126
Moreover, the following image shows the `upgrading from sh to /usr/bin/bash` message as well
Please note the `$SHELL` value

![Screenshot from 2021-06-15 04-04-00](https://user-images.githubusercontent.com/44923300/121968711-7103ef00-cd90-11eb-8d1c-74865cd71458.png)

<hr>

## sessions -k INVALID_VALUE
There is another issue within `pwncat/commands/sessions.py`.
Trying to kill an invalid session throws an error showing the _traceback_

![Screenshot from 2021-06-15 04-01-51](https://user-images.githubusercontent.com/44923300/121968141-5b41fa00-cd8f-11eb-9e0c-26e3ebbfddea.png)

> NOTE: we do not need a session for this error to pop up