### PR TITLE
[FIX #134] Pin Alpine to 3.13.5 to fix DockerHub automatic builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The Changelog starts with v0.4.1, because we did not keep one before that,
 and simply didn't have the time to go back and retroactively create one.
 
 ## [Unreleased]
+### Fixed
+- Pinned container base image to alpine 3.13.5 and installed to virtualenv ([#134](https://github.com/calebstewart/pwncat/issues/134))
 
 ## [0.4.2] - 2021-06-15
 Quick patch release due to corrected bug in `ChannelFile` which caused command

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,22 +16,23 @@ RUN set -eux \
 RUN set -eux \
 	&& python3 -m ensurepip
 
-# Ensure pip is up to date
-RUN set -eux \
-	&& python3 -m pip install -U pip setuptools wheel setuptools_rust
-
 # Copy pwncat source
 COPY . /pwncat
+
+# Setup virtual environment
+RUN set -eux \
+	&& python3 -m venv /opt/pwncat \
+	&& /opt/pwncat/bin/python3 -m pip install -U pip setuptools wheel setuptools_rust
 
 # Setup pwncat
 RUN set -eux \
 	&& cd /pwncat \
-	&& python3 setup.py install
+	&& /opt/pwncat/bin/python setup.py install
 
 # Cleanup
 RUN set -eux \
-	&& find /usr/lib -type f -name '*.pyc' -print0 | xargs -0 -n1 rm -rf || true \
-	&& find /usr/lib -type d -name '__pycache__' -print0 | xargs -0 -n1 rm -rf || true
+	&& find /opt/pwncat/lib -type f -name '*.pyc' -print0 | xargs -0 -n1 rm -rf || true \
+	&& find /opt/pwncat/lib -type d -name '__pycache__' -print0 | xargs -0 -n1 rm -rf || true
 
 
 FROM alpine:latest as final
@@ -43,11 +44,10 @@ RUN set -eux \
 	&& find /usr/lib -type d -name '__pycache__' -print0 | xargs -0 -n1 rm -rf || true \
 	&& mkdir /work
 
-COPY --from=builder /usr/bin/pwncat /usr/bin/pwncat
-COPY --from=builder /usr/lib/python3.8 /usr/lib/python3.8
+COPY --from=builder /opt/pwncat /opt/pwncat
 
-RUN python3 -m pwncat --download-plugins
+RUN /opt/pwncat/bin/python -m pwncat --download-plugins
 
 # Set working directory
 WORKDIR /work
-ENTRYPOINT ["/usr/bin/pwncat"]
+ENTRYPOINT ["/opt/pwncat/bin/pwncat"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest as builder
+FROM alpine:3.13.5 as builder
 
 # Install python3 and development files
 RUN set -eux \
@@ -12,17 +12,14 @@ RUN set -eux \
 		musl-dev \
 		cargo
 
-# Install pip
-RUN set -eux \
-	&& python3 -m ensurepip
-
 # Copy pwncat source
 COPY . /pwncat
 
 # Setup virtual environment
 RUN set -eux \
 	&& python3 -m venv /opt/pwncat \
-	&& /opt/pwncat/bin/python3 -m pip install -U pip setuptools wheel setuptools_rust
+	&& /opt/pwncat/bin/python -m ensurepip \
+	&& /opt/pwncat/bin/python -m pip install -U pip setuptools wheel setuptools_rust
 
 # Setup pwncat
 RUN set -eux \
@@ -35,7 +32,7 @@ RUN set -eux \
 	&& find /opt/pwncat/lib -type d -name '__pycache__' -print0 | xargs -0 -n1 rm -rf || true
 
 
-FROM alpine:latest as final
+FROM alpine:3.13.5 as final
 
 RUN set -eux \
 	&& apk add --no-cache \


### PR DESCRIPTION
## Description of Changes

Fixes #134.

This pull request updates the Dockerfile to pin the base image to Alpine v3.13.5, and also install pwncat within a virtual environment inside the container. DockerHub was showing a Permission Denied error when building for an unknown reason. Doing these two things appears to have fixed this. I added a test tag to the automatic builds for this branch, and the build succeeded.

## Major Changes Implemented:
- Pinned Alpine to 3.13.5 in Dockerfile
- Installed pwncat within a virtual environment at /opt/pwncat inside the container

## Pre-Merge Tasks
- [x] Formatted all modified files w/ `python-black`
- [x] Sorted imports for modified files w/ `isort`
- [x] Ran `flake8` on repo, and fixed any new problems w/ modified files
- [x] Ran `pytest` test cases
- [x] Added brief summary of updates to CHANGELOG (under `[Unreleased]`)

**For issues with pre-merge tasks, see CONTRIBUTING.md**