### PR TITLE
[FEATURE #118] Encrypted Bind and Reverse Shells 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,10 @@ and simply didn't have the time to go back and retroactively create one.
 - Changed zsh prompt to match CWD of other shell prompts
 ### Added
 - Added `ssl-bind` and `ssl-connect` channel protocols for encrypted shells
-- Added `--certificate/--cert` argument to entrypoint and `connect` command
+- Added `ncat`-style ssl arguments to entrypoint and `connect` command
 - Added query-string arguments to connection strings for both the entrypoint
   and the `connect` command.
-  
+
 ## [0.4.2] - 2021-06-15
 Quick patch release due to corrected bug in `ChannelFile` which caused command
 output to be empty in some situations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,12 @@ and simply didn't have the time to go back and retroactively create one.
 ### Changed
 - Changed session tracking so session IDs aren't reused
 - Changed zsh prompt to match CWD of other shell prompts
-
+### Added
+- Added `ssl-bind` and `ssl-connect` channel protocols for encrypted shells
+- Added `--certificate/--cert` argument to entrypoint and `connect` command
+- Added query-string arguments to connection strings for both the entrypoint
+  and the `connect` command.
+  
 ## [0.4.2] - 2021-06-15
 Quick patch release due to corrected bug in `ChannelFile` which caused command
 output to be empty in some situations.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -23,34 +23,34 @@ After installation, you can use pwncat via the installed script:
 .. code-block:: bash
 
     $ pwncat --help
-    usage: pwncat [-h] [--config CONFIG] [--identity IDENTITY] [--listen]
-                  [--platform PLATFORM] [--port PORT] [--list]
+    usage: pwncat [-h] [--version] [--download-plugins] [--config CONFIG] [--ssl] [--ssl-cert SSL_CERT]
+                  [--ssl-key SSL_KEY] [--identity IDENTITY] [--listen] [--platform PLATFORM] [--port PORT] [--list]
                   [[protocol://][user[:password]@][host][:port]] [port]
 
-    Start interactive pwncat session and optionally connect to existing victim
-    via a known platform and channel type. This entrypoint can also be used to
-    list known implants on previous targets.
+    Start interactive pwncat session and optionally connect to existing victim via a known platform and channel type. This
+    entrypoint can also be used to list known implants on previous targets.
 
     positional arguments:
       [protocol://][user[:password]@][host][:port]
                             Connection string describing victim
-      port                  Alternative port number to support netcat-style
-                            syntax
+      port                  Alternative port number to support netcat-style syntax
 
     optional arguments:
       -h, --help            show this help message and exit
+      --version, -v         Show version number and exit
+      --download-plugins    Pre-download all Windows builtin plugins and exit immediately
       --config CONFIG, -c CONFIG
                             Custom configuration file (default: ./pwncatrc)
+      --ssl                 Connect or listen with SSL
+      --ssl-cert SSL_CERT   Certificate for SSL-encrypted listeners (PEM)
+      --ssl-key SSL_KEY     Key for SSL-encrypted listeners (PEM)
       --identity IDENTITY, -i IDENTITY
                             Private key for SSH authentication
-      --listen, -l          Enable the `bind` protocol (supports netcat-style
-                            syntax)
+      --listen, -l          Enable the `bind` protocol (supports netcat-style syntax)
       --platform PLATFORM, -m PLATFORM
                             Name of the platform to use (default: linux)
-      --port PORT, -p PORT  Alternative way to specify port to support netcat-
-                            style syntax
-      --list                List installed implants with remote connection
-                            capability
+      --port PORT, -p PORT  Alternative way to specify port to support netcat-style syntax
+      --list                List installed implants with remote connection capability
 
 Windows Plugin Binaries
 -----------------------

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -37,9 +37,7 @@ authenticate to the victim host with provided credentials and utilize the SSH sh
 pwncat also implements SSL-wrapped versions of ``bind`` and ``connect`` protocols aptly named ``ssl-bind``
 and ``ssl-connect``. These protocols function largely the same as bind/connect, except that they operate
 over an encrypted SSL tunnel. You must use an encrypted bind or reverse shell on the victim side such
-as ``ncat --ssl`` or `socat OPENSSL-LISTEN:`. For the ``ssl-bind`` protocol, you must also supply either
-the ``--certificate`` argument pointing to a PEM formatted bundled certificate and key file or two
-querystring parameters named ``certfile`` and ``keyfile``.
+as ``ncat --ssl`` or `socat OPENSSL-LISTEN:`.
 
 pwncat exposes these different C2 channel protocols via the ``protocol`` field of the connection string
 discussed below.
@@ -61,14 +59,17 @@ If the ``protocol`` field is not specified, pwncat will attempt to figure out th
 contextually. The following rules apply:
 
 - If a user and host are provided, assume ``ssh`` protocol
-- If no user is provided but a host and port are provided, assume protocol is ``connect``
-- If no user or host is provided (or host is ``0.0.0.0``) and the ``certfile`` or ``keyfile`` arguments are
-  provided, protocol is assumed to be ``ssl-bind``
+- If no user is provided but a host, port and the ``--ssl`` argument, assume protocol is ``ssl-connect``
+- If no user is provided but a host and port are provided and no ``--ssl``, assume protocol is ``connect``
+- If no user or host is provided (or host is ``0.0.0.0``) and the ``certfile``, ``keyfile``, or
+  ``--ssl`` arguments are provided, protocol is assumed to be ``ssl-bind``
 - If no user or host is provided (or host is ``0.0.0.0``), protocol is assumed to be ``bind``
-- If a second positional integer parameter is specified, the protocol is assumed to be ``connect``
-  - This is the ``netcat`` syntax seen in the below examples for the ``connect`` protocol.
-- If the ``-l`` parameter is used and the ``certfile`` or ``keyfile`` arguments are provided, the protocol
-  is assumed to be ``ssl-bind``.
+- If a second positional integer parameter is specified and ``--ssl`` is not, the protocol is assumed
+  to be ``connect``
+- If a second positional integer parameter is specified and ``--ssl`` is provided, the protocol is
+  assumed to be ``ssl-connect``
+- If the ``-l`` parameter is used and the ``certfile``, ``keyfile``, or ``--ssl`` arguments are
+  provided, the protocol is assumed to be ``ssl-bind``.
 - If the ``-l`` parameter is used alone, then the protocol is assumed to be ``bind``
 
 Connecting to a victim bind shell
@@ -98,6 +99,9 @@ address which is routable (e.g. not NAT'd). The ``ssl-connect`` protocol provide
 
     # Full connection string
     pwncat connect://192.168.1.1:4444
+    # ncat style syntax
+    pwncat --ssl 192.168.1.1 4444
+    pwncat --ssl 192.168.1.1:4444
 
 Catching a victim reverse shell
 -------------------------------
@@ -125,21 +129,21 @@ In this case, the victim was exploited in such a way that they open an ssl conne
 on a specific port with a raw shell open on the other end. Your attacking host must be routable from the
 victim machine. This mode is accessed via the ``ssl-bind`` protocol.
 
-If using the ``--cert/--certificate`` argument, you must provided a combined certificate and key file in PEM
-format. If your key and certificate are stored in separate files, you should specify the ``certfile`` and
-``keyfile`` querystring arguments instead.
+If the explicit ``ssl-bind`` protocol or the ``--ssl`` argument is provided without an explicit certfile
+or keyfile, a self-signed certificate is generated with dummy attributes. The certfile and keyfile can
+both point to the same bundled PEM file if both the key and certificate are present.
 
 .. code-block:: bash
     :caption: Catching a reverse shell
 
-    # netcat syntax
-    pwncat -l --cert /path/to/cert.pem  4444
+    # ncat style syntax
+    pwncat --ssl --ssl-cert cert.pem --ssl-key cert.pem -lp 4444
     # Full connection string
     pwncat ssl-bind://0.0.0.0:4444?certfile=/path/to/cert.pem&keyfile=/path/to/key.pem
-    # Assumed protocol
-    pwncat --cert /path/to/cert.pem 0.0.0.0:4444
-    # Assumed protocol, assumed bind address
-    pwncat --cert /path/to/cert.pem :4444
+    # Auto-generated self-signed certificate
+    pwncat --ssl -lp 4444
+    # Auto-generated self-signed certificate with explicit protocol
+    pwncat ssl-bind://0.0.0.0:4444
 
 Connecting to a Remote SSH Server
 ---------------------------------

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -34,6 +34,13 @@ with three different C2 protocols: ``bind``, ``connect``, and ``ssh``. The first
 modes simply open a raw socket and assume there is a shell on the other end. In SSH mode, we legitimately
 authenticate to the victim host with provided credentials and utilize the SSH shell channel as our C2 channel.
 
+pwncat also implements SSL-wrapped versions of ``bind`` and ``connect`` protocols aptly named ``ssl-bind``
+and ``ssl-connect``. These protocols function largely the same as bind/connect, except that they operate
+over an encrypted SSL tunnel. You must use an encrypted bind or reverse shell on the victim side such
+as ``ncat --ssl`` or `socat OPENSSL-LISTEN:`. For the ``ssl-bind`` protocol, you must also supply either
+the ``--certificate`` argument pointing to a PEM formatted bundled certificate and key file or two
+querystring parameters named ``certfile`` and ``keyfile``.
+
 pwncat exposes these different C2 channel protocols via the ``protocol`` field of the connection string
 discussed below.
 
@@ -42,22 +49,27 @@ Connecting to a Victim
 
 Connecting to a victim is accomplished through a connection string. Connection strings are versatile ways
 to describe the parameters to a specific C2 Channel/Protocol. This looks something like:
-``[protocol://][user[:password]]@[host:][port]``
+``[protocol://][user[:password]]@[host:][port][?arg1=value&arg2=value]``
 
 Each field in the connection string translates to a parameter passed to the C2 channel. Some channels don't
 require all the parameters. For example, a ``bind`` or ``connect`` channel doesn't required a username or
-a password.
+a password. If there is not an explicit argument or parsed value within the above format, you can use the
+query string arguments to specify arbitrary channel arguments. You cannot specify the same argument twice
+(e.g. ``connect://hostname:1111?port=4444``).
 
 If the ``protocol`` field is not specified, pwncat will attempt to figure out the correct protocol
 contextually. The following rules apply:
 
 - If a user and host are provided, assume ``ssh`` protocol
 - If no user is provided but a host and port are provided, assume protocol is ``connect``
+- If no user or host is provided (or host is ``0.0.0.0``) and the ``certfile`` or ``keyfile`` arguments are
+  provided, protocol is assumed to be ``ssl-bind``
 - If no user or host is provided (or host is ``0.0.0.0``), protocol is assumed to be ``bind``
 - If a second positional integer parameter is specified, the protocol is assumed to be ``connect``
   - This is the ``netcat`` syntax seen in the below examples for the ``connect`` protocol.
-- If the ``-l`` parameter is used, the protocol is assumed to be ``bind``.
-  - This is the ``netcat`` syntax seen in the below examples for the ``bind`` protocol.
+- If the ``-l`` parameter is used and the ``certfile`` or ``keyfile`` arguments are provided, the protocol
+  is assumed to be ``ssl-bind``.
+- If the ``-l`` parameter is used alone, then the protocol is assumed to be ``bind``
 
 Connecting to a victim bind shell
 ---------------------------------
@@ -74,6 +86,18 @@ address which is routable (e.g. not NAT'd). The ``connect`` protocol provides th
     pwncat connect://192.168.1.1:4444
     # Connection string with assumed protocol
     pwncat 192.168.1.1:4444
+
+Connecting to a victim encrypted bind shell
+-------------------------------------------
+
+In this case, the victim is running a ssl-wrapped bind shell on an open port. The victim must be available at an
+address which is routable (e.g. not NAT'd). The ``ssl-connect`` protocol provides this capability.
+
+.. code-block:: bash
+    :caption: Connecting to a bind shell at 1.1.1.1:4444
+
+    # Full connection string
+    pwncat connect://192.168.1.1:4444
 
 Catching a victim reverse shell
 -------------------------------
@@ -93,6 +117,29 @@ victim machine. This mode is accessed via the ``bind`` protocol.
     pwncat 0.0.0.0:4444
     # Assumed protocol, assumed bind address
     pwncat :4444
+
+Catching a victim encrypted reverse shell
+-----------------------------------------
+
+In this case, the victim was exploited in such a way that they open an ssl connection to your attacking host
+on a specific port with a raw shell open on the other end. Your attacking host must be routable from the
+victim machine. This mode is accessed via the ``ssl-bind`` protocol.
+
+If using the ``--cert/--certificate`` argument, you must provided a combined certificate and key file in PEM
+format. If your key and certificate are stored in separate files, you should specify the ``certfile`` and
+``keyfile`` querystring arguments instead.
+
+.. code-block:: bash
+    :caption: Catching a reverse shell
+
+    # netcat syntax
+    pwncat -l --cert /path/to/cert.pem  4444
+    # Full connection string
+    pwncat ssl-bind://0.0.0.0:4444?certfile=/path/to/cert.pem&keyfile=/path/to/key.pem
+    # Assumed protocol
+    pwncat --cert /path/to/cert.pem 0.0.0.0:4444
+    # Assumed protocol, assumed bind address
+    pwncat --cert /path/to/cert.pem :4444
 
 Connecting to a Remote SSH Server
 ---------------------------------

--- a/pwncat/__main__.py
+++ b/pwncat/__main__.py
@@ -268,7 +268,10 @@ def main():
                     task = progress.add_task("", status="...")
                     for target, implant_user, implant in implants:
                         # Check correct query_args["user"]
-                        if query_args["user"] is not None and implant_user.name != user:
+                        if (
+                            query_args["user"] is not None
+                            and implant_user.name != query_args["user"]
+                        ):
                             continue
                         # Check correct platform
                         if (

--- a/pwncat/__main__.py
+++ b/pwncat/__main__.py
@@ -248,7 +248,7 @@ def main():
                         continue
 
                     # Collect users
-                    userss = {}
+                    users = {}
                     for fact in target.facts:
                         if "user" in fact.types:
                             users[fact.id] = fact

--- a/pwncat/__main__.py
+++ b/pwncat/__main__.py
@@ -39,11 +39,16 @@ def main():
         default=None,
         help="Custom configuration file (default: ./pwncatrc)",
     )
+    parser.add_argument("--ssl", action="store_true", help="Connect or listen with SSL")
     parser.add_argument(
-        "--certificate",
-        "--cert",
+        "--ssl-cert",
         default=None,
-        help="Certificate for SSL-encrypted listeners",
+        help="Certificate for SSL-encrypted listeners (PEM)",
+    )
+    parser.add_argument(
+        "--ssl-key",
+        default=None,
+        help="Key for SSL-encrypted listeners (PEM)",
     )
     parser.add_argument(
         "--identity",
@@ -163,8 +168,9 @@ def main():
             query_args["port"] = None
             query_args["platform"] = args.platform
             query_args["identity"] = args.identity
-            query_args["certfile"] = args.certificate
-            query_args["keyfile"] = args.certificate
+            query_args["certfile"] = args.ssl_cert
+            query_args["keyfile"] = args.ssl_key
+            query_args["ssl"] = args.ssl
             querystring = None
 
             if args.connection_string:
@@ -198,6 +204,23 @@ def main():
             if query_args["protocol"] is not None and args.listen:
                 console.log(
                     "[red]error[/red]: --listen is not compatible with an explicit connection string"
+                )
+                return
+
+            if (
+                query_args["certfile"] is None and query_args["keyfile"] is not None
+            ) or (query_args["certfile"] is not None and query_args["keyfile"] is None):
+                console.log(
+                    "[red]error[/red]: both a ssl certificate and key file are required"
+                )
+                return
+
+            if query_args["certfile"] is not None or query_args["keyfile"] is not None:
+                query_args["ssl"] = True
+
+            if query_args["protocol"] is not None and args.ssl:
+                console.log(
+                    "[red]error[/red]: --ssl is incompatible with an explicit protocol"
                 )
                 return
 

--- a/pwncat/channel/__init__.py
+++ b/pwncat/channel/__init__.py
@@ -581,7 +581,10 @@ def create(protocol: Optional[str] = None, **kwargs) -> Channel:
                 or kwargs["host"] == "0.0.0.0"
                 or kwargs["host"] is None
             ):
-                if "certfile" in kwargs or "keyfile" in kwargs:
+                if (
+                    kwargs.get("certfile") is not None
+                    or kwargs.get("keyfile") is not None
+                ):
                     protocols.append("ssl-bind")
                 else:
                     protocols.append("bind")

--- a/pwncat/channel/__init__.py
+++ b/pwncat/channel/__init__.py
@@ -604,9 +604,11 @@ from pwncat.channel.bind import Bind  # noqa: E402
 from pwncat.channel.socket import Socket  # noqa: E402
 from pwncat.channel.connect import Connect  # noqa: E402
 from pwncat.channel.ssl_bind import SSLBind  # noqa: E402
+from pwncat.channel.ssl_connect import SSLConnect  # noqa: E402
 
 register("socket", Socket)
 register("bind", Bind)
 register("connect", Connect)
 register("ssh", Ssh)
 register("ssl-bind", SSLBind)
+register("ssl-connect", SSLConnect)

--- a/pwncat/channel/__init__.py
+++ b/pwncat/channel/__init__.py
@@ -581,7 +581,10 @@ def create(protocol: Optional[str] = None, **kwargs) -> Channel:
                 or kwargs["host"] == "0.0.0.0"
                 or kwargs["host"] is None
             ):
-                protocols.append("bind")
+                if "certfile" in kwargs or "keyfile" in kwargs:
+                    protocols.append("ssl-bind")
+                else:
+                    protocols.append("bind")
             else:
                 protocols.append("connect")
     else:
@@ -600,8 +603,10 @@ from pwncat.channel.ssh import Ssh  # noqa: E402
 from pwncat.channel.bind import Bind  # noqa: E402
 from pwncat.channel.socket import Socket  # noqa: E402
 from pwncat.channel.connect import Connect  # noqa: E402
+from pwncat.channel.ssl_bind import SSLBind  # noqa: E402
 
 register("socket", Socket)
 register("bind", Bind)
 register("connect", Connect)
 register("ssh", Ssh)
+register("ssl-bind", SSLBind)

--- a/pwncat/channel/__init__.py
+++ b/pwncat/channel/__init__.py
@@ -584,12 +584,16 @@ def create(protocol: Optional[str] = None, **kwargs) -> Channel:
                 if (
                     kwargs.get("certfile") is not None
                     or kwargs.get("keyfile") is not None
+                    or kwargs.get("ssl")
                 ):
                     protocols.append("ssl-bind")
                 else:
                     protocols.append("bind")
             else:
-                protocols.append("connect")
+                if kwargs.get("ssl"):
+                    protocols.append("ssl-connect")
+                else:
+                    protocols.append("connect")
     else:
         protocols = [protocol]
 

--- a/pwncat/channel/bind.py
+++ b/pwncat/channel/bind.py
@@ -28,6 +28,12 @@ class Bind(Socket):
         if not host or host == "":
             host = "0.0.0.0"
 
+        if isinstance(port, str):
+            try:
+                port = int(port)
+            except ValueError:
+                raise ChannelError(self, "invalid port number")
+
         if port is None:
             raise ChannelError(self, "no port specified")
 

--- a/pwncat/channel/bind.py
+++ b/pwncat/channel/bind.py
@@ -51,6 +51,8 @@ class Bind(Socket):
                 self._socket_connected(client)
             except KeyboardInterrupt:
                 raise ChannelError(self, "listener aborted")
+            except socket.error as exc:
+                raise ChannelError(self, str(exc))
             finally:
                 self.server.close()
 

--- a/pwncat/channel/connect.py
+++ b/pwncat/channel/connect.py
@@ -24,10 +24,16 @@ class Connect(Socket):
 
     def __init__(self, host: str, port: int, **kwargs):
         if not host:
-            raise ChannelError("no host address provided")
+            raise ChannelError(self, "no host address provided")
 
         if port is None:
-            raise ChannelError("no port provided")
+            raise ChannelError(self, "no port provided")
+
+        if isinstance(port, str):
+            try:
+                port = int(port)
+            except ValueError:
+                raise ChannelError(self, "invalid port")
 
         with Progress(
             f"connecting to [blue]{host}[/blue]:[cyan]{port}[/cyan]",

--- a/pwncat/channel/socket.py
+++ b/pwncat/channel/socket.py
@@ -100,7 +100,7 @@ class Socket(Channel):
         except BrokenPipeError as exc:
             self._connected = False
             raise ChannelClosed(self) from exc
-        except (ssl.SSLEOFError, ssl.SSLSyscallError, ssl.SSLZeroReturnError):
+        except (ssl.SSLEOFError, ssl.SSLSyscallError, ssl.SSLZeroReturnError) as exc:
             self._connected = False
             raise ChannelClosed(self) from exc
 
@@ -133,7 +133,7 @@ class Socket(Channel):
             return data
         except ssl.SSLWantReadError:
             return data
-        except (ssl.SSLEOFError, ssl.SSLSyscallError, ssl.SSLZeroReturnError):
+        except (ssl.SSLEOFError, ssl.SSLSyscallError, ssl.SSLZeroReturnError) as exc:
             self._connected = False
             raise ChannelClosed(self) from exc
         except socket.error as exc:

--- a/pwncat/channel/socket.py
+++ b/pwncat/channel/socket.py
@@ -49,6 +49,9 @@ class Socket(Channel):
 
     def __init__(self, client: socket.socket = None, **kwargs):
 
+        if isinstance(client, str):
+            raise ChannelError(self, f"expected socket object not {repr(type(client))}")
+
         if client is not None:
             # Report host and port number to base channel
             host, port = client.getpeername()

--- a/pwncat/channel/ssl_bind.py
+++ b/pwncat/channel/ssl_bind.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python3
 import ssl
+import datetime
+import tempfile
+
+from cryptography import x509
+from cryptography.x509.oid import NameOID
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
 
 from pwncat.channel import ChannelError
 from pwncat.channel.bind import Bind
@@ -10,6 +17,10 @@ class SSLBind(Bind):
         super().__init__(**kwargs)
 
         self.context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+
+        if certfile is None and keyfile is None:
+            certfile = keyfile = self._generate_self_signed_cert()
+
         self.context.load_cert_chain(certfile, keyfile)
 
         self.server = self.context.wrap_socket(self.server)
@@ -20,3 +31,48 @@ class SSLBind(Bind):
             super().connect()
         except ssl.SSLError as exc:
             raise ChannelError(self, str(exc))
+
+    def _generate_self_signed_cert(self):
+        """Generate a self-signed certificate"""
+
+        with tempfile.NamedTemporaryFile("wb", delete=False) as filp:
+            key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+            filp.write(
+                key.private_bytes(
+                    encoding=serialization.Encoding.PEM,
+                    format=serialization.PrivateFormat.TraditionalOpenSSL,
+                    encryption_algorithm=serialization.NoEncryption(),
+                )
+            )
+
+            # Literally taken from: https://cryptography.io/en/latest/x509/tutorial/
+            subject = issuer = x509.Name(
+                [
+                    x509.NameAttribute(NameOID.COUNTRY_NAME, u"US"),
+                    x509.NameAttribute(NameOID.COUNTRY_NAME, u"US"),
+                    x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, u"California"),
+                    x509.NameAttribute(NameOID.LOCALITY_NAME, u"San Francisco"),
+                    x509.NameAttribute(NameOID.ORGANIZATION_NAME, u"My Company"),
+                    x509.NameAttribute(NameOID.COMMON_NAME, u"mysite.com"),
+                ]
+            )
+            cert = (
+                x509.CertificateBuilder()
+                .subject_name(subject)
+                .issuer_name(issuer)
+                .public_key(key.public_key())
+                .serial_number(x509.random_serial_number())
+                .not_valid_before(datetime.datetime.utcnow())
+                .not_valid_after(
+                    datetime.datetime.utcnow() + datetime.timedelta(days=365)
+                )
+                .add_extension(
+                    x509.SubjectAlternativeName([x509.DNSName(u"localhost")]),
+                    critical=False,
+                )
+                .sign(key, hashes.SHA256())
+            )
+
+            filp.write(cert.public_bytes(serialization.Encoding.PEM))
+
+            return filp.name

--- a/pwncat/channel/ssl_bind.py
+++ b/pwncat/channel/ssl_bind.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+import ssl
+
+from pwncat.channel import ChannelError
+from pwncat.channel.bind import Bind
+
+
+class SSLBind(Bind):
+    def __init__(self, certfile: str = None, keyfile: str = None, **kwargs):
+        super().__init__(**kwargs)
+
+        self.context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        self.context.load_cert_chain(certfile, keyfile)
+
+        self.server = self.context.wrap_socket(self.server)
+
+    def connect(self):
+
+        try:
+            super().connect()
+        except ssl.SSLError as exc:
+            raise ChannelError(self, str(exc))

--- a/pwncat/channel/ssl_connect.py
+++ b/pwncat/channel/ssl_connect.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+import ssl
+
+from pwncat.channel import ChannelError
+from pwncat.channel.connect import Connect
+
+
+class SSLConnect(Connect):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def _socket_connected(self, client):
+        try:
+            self.context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+            self.context.check_hostname = False
+            self.context.verify_mode = ssl.VerifyMode.CERT_NONE
+
+            client = self.context.wrap_socket(client)
+        except ssl.SSLError as exc:
+            raise ChannelError(str(exc))
+
+        super()._socket_connected(client)

--- a/pwncat/commands/connect.py
+++ b/pwncat/commands/connect.py
@@ -237,7 +237,10 @@ class Command(CommandDefinition):
                 task = progress.add_task("", status="...")
                 for target, implant_user, implant in implants:
                     # Check correct query_args["user"]
-                    if query_args["user"] is not None and implant_user.name != user:
+                    if (
+                        query_args["user"] is not None
+                        and implant_user.name != query_args["user"]
+                    ):
                         continue
                     # Check correct platform
                     if (

--- a/pwncat/commands/connect.py
+++ b/pwncat/commands/connect.py
@@ -217,7 +217,7 @@ class Command(CommandDefinition):
                     continue
 
                 # Collect users
-                userss = {}
+                users = {}
                 for fact in target.facts:
                     if "user" in fact.types:
                         users[fact.id] = fact

--- a/pwncat/commands/connect.py
+++ b/pwncat/commands/connect.py
@@ -58,6 +58,10 @@ class Command(CommandDefinition):
             action="store_true",
             help="List installed implants with remote connection capability",
         ),
+        "--connection,--conn": Parameter(
+            Complete.NONE,
+            help="Certificate for SSL-encrypted listeners",
+        ),
         "connection_string": Parameter(
             Complete.NONE,
             metavar="[protocol://][user[:password]@][host][:port]",
@@ -73,7 +77,7 @@ class Command(CommandDefinition):
     }
     LOCAL = True
     CONNECTION_PATTERN = re.compile(
-        r"""^(?P<protocol>[-a-zA-Z0-9_]*://)?((?P<user>[^:@]*)?(?P<password>:(\\@|[^@])*)?@)?(?P<host>[^:]*)?(?P<port>:[0-9]*)?$"""
+        r"""^(?P<protocol>[-a-zA-Z0-9_]*://)?((?P<user>[^:@]*)?(?P<password>:(\\@|[^@])*)?@)?(?P<host>[^:]*)?(?P<port>:[0-9]*)?(\?(?P<querystring>.*))?$"""
     )
 
     def run(self, manager: "pwncat.manager.Manager", args):

--- a/test.py
+++ b/test.py
@@ -19,12 +19,11 @@ with pwncat.manager.Manager("data/pwncatrc") as manager:
     # session = manager.create_session("windows", host="192.168.56.10", port=4444)
     # session = manager.create_session("windows", host="192.168.122.11", port=4444)
     # session = manager.create_session("linux", host="pwncat-ubuntu", port=4444)
-    session = manager.create_session("linux", host="127.0.0.1", port=4444)
+    # session = manager.create_session("linux", host="127.0.0.1", port=4444)
+    session = manager.create_session(
+        "linux", certfile="/tmp/cert.pem", keyfile="/tmp/cert.pem", port=4444
+    )
 
     # session.platform.powershell("amsiutils")
-
-    with open("/tmp/random", "rb") as source:
-        with session.platform.open("/tmp/random", "wb") as destination:
-            shutil.copyfileobj(source, destination)
 
     manager.interactive()


### PR DESCRIPTION
## Description of Changes
Fixes #118.

This pull requests adds two new channel classes/protocols: `ssl-bind` and `ssl-connect`. As with their unencrypted counterparts, these channels connect to or listen for a direct connection from/to the victim over a socket. After receiving or establishing a connection, the channel wraps the socket in an SSL context, and proceeds identically to the basic `bind` and `connect` channels.

The `ssl-bind` protocol requires two extra arguments: `certfile` and `keyfile`. At some point, I may implement automatic self-signed cert/key generation, but currently they must be generated separately and specified. To facilitate these new protocol options, a new argument was added to the entrypoint and the `connect` command. This argument is named `certificate` (or `cert` for short) and must point to an existing PEM formatted bundled certificate and key file. If your key and certificate are separate, you can also use the new query string syntax:

```sh
pwncat ssl-bind://0.0.0.0:4444?certfile=/path/to/cert.pem&keyfile=/path/to/key.pem
```

This implementation uses the standard `ssl` library from Python.

There was some discussion in #118 regarding implementing modules to automatically reconnect via encrypted session or upgrade an existing session to encrypted, however I believe that is outside the scope of the original issue. If @Mitul16 wants to dive into some PoCs for that functionality, I'm happy to hop into another issue to work on that, but I'd like to keep issues and pull requests focused on specific feature implementation or bug fixes.

There two `noqa:` lines added to `pwncat/channel/__init__.py:609` for `E402`. This is because the imports need to be at the bottom to automatically add register their names.

**Please note any `noqa:` comments needed to appease flake8.**

## Major Changes Implemented:
- Added `ssl-bind` and `ssl-connect` channel protocols for encrypted shells
- Added `ncat`-style arguments for the entrypoint and `connect` command (e.g. `--ssl` and `--ssl-cert`/`--ssl-key`)
- Added query-string arguments to connection strings for both the entrypoint
  and the `connect` command.

## Pre-Merge Tasks
- [x] Formatted all modified files w/ `python-black`
- [x] Sorted imports for modified files w/ `isort`
- [x] Ran `flake8` on repo, and fixed any new problems w/ modified files
- [x] Ran `pytest` test cases
- [x] Added brief summary of updates to CHANGELOG (under `[Unreleased]`)

**For issues with pre-merge tasks, see CONTRIBUTING.md**
