### PR TITLE
[FIX #140] Remove C-d Loop in LinuxWriter Close Routine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and simply didn't have the time to go back and retroactively create one.
 ### Changed
 - Changed session tracking so session IDs aren't reused
 - Changed zsh prompt to match CWD of other shell prompts
+- Changed LinuxWriter close routine again to account for needed EOF signals ([#140](https://github.com/calebstewart/pwncat/issues/140))
+### Added
+- Added better file io test cases
 
 ## [0.4.2] - 2021-06-15
 Quick patch release due to corrected bug in `ChannelFile` which caused command

--- a/pwncat/commands/upload.py
+++ b/pwncat/commands/upload.py
@@ -45,17 +45,6 @@ class Command(CommandDefinition):
 
         if not args.destination:
             args.destination = f"./{os.path.basename(args.source)}"
-        # else:
-        #     access = pwncat.victim.access(args.destination)
-        #     if Access.DIRECTORY in access:
-        #         args.destination = os.path.join(
-        #             args.destination, os.path.basename(args.source)
-        #         )
-        #     elif Access.PARENT_EXIST not in access:
-        #         console.log(
-        #             f"[cyan]{args.destination}[/cyan]: no such file or directory"
-        #         )
-        #         return
 
         try:
             length = os.path.getsize(args.source)

--- a/pwncat/util.py
+++ b/pwncat/util.py
@@ -118,9 +118,9 @@ def isprintable(data) -> bool:
 
 def human_readable_size(size, decimal_places=2):
     for unit in ["B", "KiB", "MiB", "GiB", "TiB"]:
-        if size < 1024.0:
+        if size < 1000.0:
             return f"{size:.{decimal_places}f}{unit}"
-        size /= 1024.0
+        size /= 1000.0
     return f"{size:.{decimal_places}f}{unit}"
 
 

--- a/tests/test_fileio.py
+++ b/tests/test_fileio.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+from pwncat.util import random_string
+
+
+def do_file_test(session, content):
+    """Do a generic file test"""
+
+    name = random_string() + ".txt"
+    mode = "b" if isinstance(content, bytes) else ""
+
+    with session.platform.open(name, mode + "w") as filp:
+        assert filp.write(content) == len(content)
+
+    with session.platform.open(name, mode + "r") as filp:
+        assert filp.read() == content
+
+    # In some cases, the act of reading/writing causes a shell to hang
+    # so double check that.
+    result = session.platform.run(
+        ["echo", "hello world"], capture_output=True, text=True
+    )
+    assert result.stdout == "hello world\n"
+
+
+def test_small_text(session):
+    """Test writing a small text-only file"""
+
+    do_file_test(session, "hello world")
+
+
+def test_large_text(session):
+    """Test writing and reading a large text file"""
+
+    contents = ("A" * 1000 + "\n") * 10
+    do_file_test(session, contents)
+
+
+def test_small_binary(session):
+    """Test writing a small amount of binary data"""
+
+    contents = bytes(list(range(32)))
+    do_file_test(session, contents)
+
+
+def test_large_binary(session):
+
+    contents = bytes(list(range(32))) * 400
+    do_file_test(session, contents)

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -10,27 +10,8 @@ from pwncat.util import random_string
 from pwncat.platform.windows import PowershellError
 
 
-def test_platform_file_io(session):
-    """ Test file read/write of printable data """
-
-    # Generate random binary data
-    contents = os.urandom(1024)
-
-    # Create a new temporary file
-    with session.platform.tempfile(mode="wb") as filp:
-        filp.write(contents)
-        path = filp.name
-
-    # Ensure it exists
-    assert session.platform.Path(path).exists()
-
-    # Read the data back and ensure it matches
-    with session.platform.open(path, "rb") as filp:
-        assert contents == filp.read()
-
-
 def test_platform_dir_io(session):
-    """ Test creating a directory and interacting with the contents """
+    """Test creating a directory and interacting with the contents"""
 
     # Create a path object representing the new remote directory
     path = session.platform.Path(random_string())
@@ -61,7 +42,7 @@ def test_platform_run(session):
 
 
 def test_platform_su(session):
-    """ Test running `su` """
+    """Test running `su`"""
 
     try:
         session.platform.su("john", "P@ssw0rd")
@@ -77,7 +58,7 @@ def test_platform_su(session):
 
 
 def test_platform_sudo(session):
-    """ Testing running `sudo` """
+    """Testing running `sudo`"""
 
     try:
 
@@ -103,7 +84,7 @@ def test_platform_sudo(session):
 
 
 def test_windows_powershell(windows):
-    """ Test powershell execution """
+    """Test powershell execution"""
 
     # Run a real powershell snippet
     r = windows.platform.powershell("$PSVersionTable.PSVersion")


### PR DESCRIPTION
## Description of Changes

Fixes #140.

With these changes, when exiting a file write process, we send 2 EOFs if that last sent character was a new line and 4 if the last sent character was not a new line. This is counter-intuitive, but from all my testing, this appears to work consistently. I've added test cases for large and small files with both binary data and printable/text data and all tests pass as well as tests with the original TryHackMe machine which the issue was reported for.

It appears that you need to send every C-d twice, but I can't figure out why. All manual testing only requires a single C-d, but double each seems to correctly behave with automated file IO. If someone can explain this, I'd be very interested, but I cannot figure it out. In any case, this seems to work with the pwncat-testing docker images as well as [toc2](https://tryhackme.com/room/toc2) as mentioned in #140. I was able to upload binary files, and `linpeas.sh` to `toc2` w/ no hangs, and matching hashes with this branch.

## Major Changes Implemented:
- Removed `C-d` loop in `LinuxWriter.close`
- Added double `C-d` routine based on last character written to `LinuxWriter.close`
- Changed upload success message to match size calculations from `rich.progress`.
- Added better file IO test cases (small text, large text, small binary, large binary)

## Pre-Merge Tasks
- [x] Formatted all modified files w/ `python-black`
- [x] Sorted imports for modified files w/ `isort`
- [x] Ran `flake8` on repo, and fixed any new problems w/ modified files
- [x] Ran `pytest` test cases
- [x] Added brief summary of updates to CHANGELOG (under `[Unreleased]`)

**For issues with pre-merge tasks, see CONTRIBUTING.md**