### PR TITLE
Re-added readline import after regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and simply didn't have the time to go back and retroactively create one.
 ### Fixed
 - Pinned container base image to alpine 3.13.5 and installed to virtualenv ([#134](https://github.com/calebstewart/pwncat/issues/134))
 - Fixed syntax for f-strings in escalation command
+- Re-added `readline` import for windows platform after being accidentally removed
 ### Changed
 - Changed session tracking so session IDs aren't reused
 - Changed zsh prompt to match CWD of other shell prompts

--- a/pwncat/platform/windows.py
+++ b/pwncat/platform/windows.py
@@ -26,6 +26,7 @@ import hashlib
 import pathlib
 import tarfile
 import binascii
+import readline  # noqa: F401
 import functools
 import threading
 import subprocess


### PR DESCRIPTION
## Description of Changes

The `readline` import was accidentally removed during `flake8` cleanup. This broke the remote shell for Windows targets. I've added it back with a `noqa: F401` tag to appease flake8.

## Major Changes Implemented:
- Re-added readline import to windows platform

## Pre-Merge Tasks
- [x] Formatted all modified files w/ `python-black`
- [x] Sorted imports for modified files w/ `isort`
- [x] Ran `flake8` on repo, and fixed any new problems w/ modified files
- [x] Ran `pytest` test cases
- [x] Added brief summary of updates to CHANGELOG (under `[Unreleased]`)

**For issues with pre-merge tasks, see CONTRIBUTING.md**
