### PR TITLE
[FEATURE #43] Background Listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and simply didn't have the time to go back and retroactively create one.
 - Added query-string arguments to connection strings for both the entrypoint
   and the `connect` command.
 - Added Enumeration States to allow session-bound enumerations
+- Added background listener API and commands ([#43](https://github.com/calebstewart/pwncat/issues/43))
 
 ## [0.4.3] - 2021-06-18
 Patch fix release. Major fixes are the correction of file IO for LinuxWriters and

--- a/docs/source/api/pwncat.facts.escalate.rst
+++ b/docs/source/api/pwncat.facts.escalate.rst
@@ -1,7 +1,0 @@
-pwncat.facts.escalate module
-============================
-
-.. automodule:: pwncat.facts.escalate
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/docs/source/api/pwncat.facts.rst
+++ b/docs/source/api/pwncat.facts.rst
@@ -13,7 +13,6 @@ Modules and Packages
    :maxdepth: -1
 
    pwncat.facts.ability
-   pwncat.facts.escalate
    pwncat.facts.implant
    pwncat.facts.linux
    pwncat.facts.tamper

--- a/docs/source/commands/index.rst
+++ b/docs/source/commands/index.rst
@@ -13,6 +13,8 @@ Command index
     download.rst
     escalate.rst
     load.rst
+    listen.rst
+    listeners.rst
     run.rst
     info.rst
     search.rst

--- a/docs/source/commands/listen.rst
+++ b/docs/source/commands/listen.rst
@@ -1,0 +1,21 @@
+Listen
+======
+
+Create a new background listener to asynchronously establish sessions via a reverse shell payload. Background listeners can operate in two different modes: with a platform and without. If a platform type is not specified when creating a listener, channels will be queued within the listener until you initialize them with the ``listeners`` command.
+
+Using the ``--drop-duplicate`` option will cause pwncat to drop any new sessions which duplicate both the target host and user of an existing session. This could be useful when using an infinite reverse shell implant.
+
+Currently, listeners can only be used with the ``socket`` protocol, however listeners are capable of wrapping the socket server in an SSL context. A background listener can effectively replace the ``bind://`` and ``ssl-bind://`` protocols.
+
+The ``--count`` option can be used to restrict background listeners to a set number of active sessions. After reaching the number specified by ``--count``, the listener will automatically be stopped.
+
+.. code-block:: bash
+
+    # Create a basic listener for linux sessions on port 9999
+    listen -m linux 9999
+    # Create an SSL listener for linux sessions on port 6666
+    listen -m linux --ssl 9999
+    # Create a listener with no platform which caches channels until initialization
+    listen 8888
+    # Create a listener which automatically exits after 4 established sessions
+    listen --count 4 --platform windows 5555

--- a/docs/source/commands/listeners.rst
+++ b/docs/source/commands/listeners.rst
@@ -1,0 +1,20 @@
+Listeners
+=========
+
+The ``listeners`` command is used to manager active and stopped listeners. This command provides the capability to view listener configuration, stop active listeners, view failure messages, and initialize queued channels.
+
+When initializing a channel, you will be shown a list of pending channels, of which you can select and define a platform name. After specifying a platform, a session will be established with the channel and you will have the option of initializing other queue channels.
+
+.. code-block:: bash
+    :caption: Interacting with Listeners
+
+    # List only running and failed listeners
+    listeners
+    # List all listeners (running, stopped, and failed)
+    listeners --all
+    # Kill listener with ID 0
+    listeners -k 0
+    # View listener configuration (and failure message)
+    listeners 0
+    # Initialize pending channels
+    listeners --init 0

--- a/pwncat/commands/__init__.py
+++ b/pwncat/commands/__init__.py
@@ -793,9 +793,14 @@ class CommandLexer(RegexLexer):
         """Build the RegexLexer token list from the command definitions"""
 
         root = []
-        for command in commands:
+        sorted_commands = sorted(commands, key=lambda cmd: len(cmd.PROG), reverse=True)
+        for command in sorted_commands:
             root.append(
-                ("^" + re.escape(command.PROG), token.Name.Function, command.PROG)
+                (
+                    "^" + re.escape(command.PROG) + "( |$)",
+                    token.Name.Function,
+                    command.PROG,
+                )
             )
             mode = []
             if command.ARGS is not None:

--- a/pwncat/commands/__init__.py
+++ b/pwncat/commands/__init__.py
@@ -66,6 +66,7 @@ from prompt_toolkit.completion import (
 )
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
+from prompt_toolkit.patch_stdout import patch_stdout
 from prompt_toolkit.styles.pygments import style_from_pygments_cls
 from prompt_toolkit.application.current import get_app
 
@@ -556,6 +557,7 @@ class CommandParser:
             self.setup_prompt()
 
         running = True
+        default_text = ""
 
         while running:
             try:
@@ -576,7 +578,10 @@ class CommandParser:
                         ("", "$ "),
                     ]
 
-                line = self.prompt.prompt().strip()
+                with patch_stdout(raw=True):
+                    line = self.prompt.prompt(default=default_text).strip()
+
+                default_text = ""
 
                 if line == "":
                     continue

--- a/pwncat/commands/listener_new.py
+++ b/pwncat/commands/listener_new.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+from rich.prompt import Confirm
+
+import pwncat
+from pwncat.util import console
+from pwncat.manager import ListenerState
+from pwncat.commands import Complete, Parameter, CommandDefinition
+
+
+class Command(CommandDefinition):
+    """
+    Create a new background listener. Background listeners will continue
+    listening while you do other things in pwncat. When a connection is
+    established, the listener will either queue the new channel for
+    future initialization or construct a full session.
+
+    If a platform is provided, a session will automatically be established
+    for any new incoming connections. If no platform is provided, the
+    channels will be queued, and can be initialized with the 'listeners'
+    command.
+
+    If the drop_duplicate option is provided, sessions which connect to
+    a host which already has an active session with the same user will
+    be automatically dropped. This facilitates an infinite callback implant
+    which you don't want to pollute the active session list.
+    """
+
+    PROG = "listen"
+    ARGS = {
+        "--count,-c": Parameter(
+            Complete.NONE,
+            type=int,
+            help="Number of sessions a listener should accept before automatically stopping (default: infinite)",
+        ),
+        "--platform,-m": Parameter(
+            Complete.NONE,
+            type=str,
+            help="Name of the platform used to automatically construct a session for a new connection",
+        ),
+        "--ssl": Parameter(
+            Complete.NONE,
+            action="store_true",
+            default=False,
+            help="Wrap a new listener in an SSL context",
+        ),
+        "--ssl-cert": Parameter(
+            Complete.LOCAL_FILE,
+            help="SSL Server Certificate for SSL wrapped listeners",
+        ),
+        "--ssl-key": Parameter(
+            Complete.LOCAL_FILE,
+            help="SSL Server Private Key for SSL wrapped listeners",
+        ),
+        "--host,-H": Parameter(
+            Complete.NONE,
+            help="Host address on which to bind (default: 0.0.0.0)",
+            default="0.0.0.0",
+        ),
+        "port": Parameter(
+            Complete.NONE,
+            type=int,
+            help="Port on which to listen for new listeners",
+        ),
+        "--drop-duplicate,-D": Parameter(
+            Complete.NONE,
+            action="store_true",
+            help="Automatically drop sessions with hosts that are already active",
+        ),
+    }
+    LOCAL = True
+
+    def _drop_duplicate(self, session: "pwncat.manager.Session"):
+
+        for other in session.manager.sessions.values():
+            if (
+                other is not session
+                and session.hash == other.hash
+                and session.platform.getuid() == other.platform.getuid()
+            ):
+                session.log("dropping duplicate session")
+                return False
+
+        return True
+
+    def run(self, manager: "pwncat.manager.Manager", args):
+
+        if args.drop_duplicate:
+            established = self._drop_duplicate
+
+        if args.platform is None:
+            manager.print(
+                "You have not specified a platform. Connections will be queued until initialized with the 'listeners' command."
+            )
+            if not Confirm.ask("Are you sure?"):
+                return
+
+        with console.status("creating listener..."):
+            listener = manager.create_listener(
+                protocol="socket",
+                platform=args.platform,
+                host=args.host,
+                port=args.port,
+                ssl=args.ssl,
+                ssl_cert=args.ssl_cert,
+                ssl_key=args.ssl_key,
+                established=established,
+                count=args.count,
+            )
+
+            while listener.state is ListenerState.STOPPED:
+                pass
+
+        if listener.state is ListenerState.FAILED:
+            manager.log(
+                f"[red]error[/red]: listener startup failed: {listener.failure_exception}"
+            )
+        else:
+            manager.log(f"new listener created for {listener}")

--- a/pwncat/commands/listener_new.py
+++ b/pwncat/commands/listener_new.py
@@ -86,6 +86,8 @@ class Command(CommandDefinition):
 
         if args.drop_duplicate:
             established = self._drop_duplicate
+        else:
+            established = None
 
         if args.platform is None:
             manager.print(

--- a/pwncat/commands/listeners.py
+++ b/pwncat/commands/listeners.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+from rich import box
+from rich.table import Table
+from rich.prompt import Prompt
+
+import pwncat
+from pwncat.util import console
+from pwncat.manager import Listener, ListenerError, ListenerState
+from pwncat.commands import Complete, Parameter, CommandDefinition
+
+
+class Command(CommandDefinition):
+    """
+    Manage active or stopped background listeners. This command
+    is only used to interact with established listeners. For
+    creating new listeners, use the "listen" command instead.
+    """
+
+    PROG = "listeners"
+    ARGS = {
+        "--all,-a": Parameter(
+            Complete.NONE,
+            action="store_true",
+            help="Show all listeners when listing (default: hide stopped)",
+        ),
+        "--kill,-k": Parameter(
+            Complete.NONE, action="store_true", help="Stop the given listener"
+        ),
+        "--init,-i": Parameter(
+            Complete.NONE, action="store_true", help="Initialize pending channels"
+        ),
+        "id": Parameter(
+            Complete.NONE,
+            type=int,
+            nargs="?",
+            help="The specific listener to interact with",
+        ),
+    }
+    LOCAL = True
+
+    def _init_channel(self, manager: pwncat.manager.Manager, listener: Listener):
+        """Initialize pending channel"""
+
+        # Grab list of pending channels
+        channels = list(listener.iter_channels())
+        if not channels:
+            manager.log("no pending channels")
+            return
+
+        manager.print(f"Pending Channels for {listener}:")
+        for ident, channel in enumerate(channels):
+            manager.print(f"{ident}. {channel}")
+
+        manager.print("\nPress C-c to stop initializing channels.")
+
+        platform = "linux"
+
+        try:
+            while True:
+                if not any(chan is not None for chan in channels):
+                    manager.log("all pending channels configured")
+                    break
+
+                ident = int(
+                    Prompt.ask(
+                        "Channel Index",
+                        choices=[
+                            str(x)
+                            for x in range(len(channels))
+                            if channels[x] is not None
+                        ],
+                    )
+                )
+                if channels[ident] is None:
+                    manager.print("[red]error[/red]: channel already initialized.")
+                    continue
+
+                platform = Prompt.ask(
+                    "Platform Name",
+                    default=platform,
+                    choices=["linux", "windows", "drop"],
+                    show_default=True,
+                )
+
+                if platform == "drop":
+                    manager.log(f"dropping channel: {channels[ident]}")
+                    channels[ident].close()
+                    channels[ident] = None
+                    continue
+
+                try:
+                    listener.bootstrap_session(channels[ident], platform)
+                    channels[ident] = None
+                except ListenerError as exc:
+                    manager.log(f"channel bootstrap failed: {exc}")
+                    channels[ident].close()
+                    channels[ident] = None
+        except KeyboardInterrupt:
+            manager.print("")
+            pass
+        finally:
+            for channel in channels:
+                if channel is not None:
+                    listener.bootstrap_session(channel, platform=None)
+
+    def _show_listener(self, manager: pwncat.manager.Manager, listener: Listener):
+        """Show detailed information on a listener"""
+
+        # Makes printing the variables a little more straightforward
+        def dump_var(name, value):
+            manager.print(f"[yellow]{name}[/yellow] = {value}")
+
+        # Dump common state
+        dump_var("address", str(listener))
+
+        state_color = "green"
+        if listener.state is ListenerState.FAILED:
+            state_color = "red"
+        elif listener.state is ListenerState.STOPPED:
+            state_color = "yellow"
+
+        dump_var(
+            "state",
+            f"[{state_color}]"
+            + str(listener.state).split(".")[1]
+            + f"[/{state_color}]",
+        )
+
+        # If the listener failed, show the failure message
+        if listener.state is ListenerState.FAILED:
+            dump_var("[red]error[/red]", repr(str(listener.failure_exception)))
+
+        dump_var("protocol", repr(listener.protocol))
+        dump_var("platform", repr(listener.platform))
+
+        # A count of None means infinity, annotate that
+        if listener.count is not None:
+            dump_var("remaining", listener.count)
+        else:
+            dump_var("remaining", "[red]infinite[/red]")
+
+        # Number of pending channels
+        dump_var("pending", listener.pending)
+
+        # SSL settings
+        dump_var("ssl", repr(listener.ssl))
+        if listener.ssl:
+            dump_var("ssl_cert", repr(listener.ssl_cert))
+            dump_var("ssl_key", repr(listener.ssl_key))
+
+    def run(self, manager: "pwncat.manager.Manager", args):
+
+        if (args.kill or args.init) and args.id is None:
+            self.parser.error("missing argument: id")
+
+        if args.kill and args.init:
+            self.parser.error("cannot use both kill and init arguments")
+
+        if args.id is not None and (args.id < 0 or args.id >= len(manager.listeners)):
+            self.parser.error(f"invalid listener id: {args.id}")
+
+        if args.kill:
+            # Kill the specified listener
+            with console.status("stopping listener..."):
+                manager.listeners[args.id].stop()
+            manager.log(f"stopped listener on {str(manager.listeners[args.id])}")
+            return
+
+        if args.init:
+            self._init_channel(manager, manager.listeners[args.id])
+            return
+
+        if args.id is not None:
+            self._show_listener(manager, manager.listeners[args.id])
+            return
+
+        table = Table(
+            "ID",
+            "State",
+            "Address",
+            "Platform",
+            "Remaining",
+            "Pending",
+            title="Listeners",
+            box=box.MINIMAL_DOUBLE_HEAD,
+        )
+
+        for ident, listener in enumerate(manager.listeners):
+
+            if listener.state is ListenerState.STOPPED and not args.all:
+                continue
+
+            if listener.count is None:
+                count = "[red]inf[/red]"
+            else:
+                count = str(listener.count)
+
+            table.add_row(
+                str(ident),
+                str(listener.state).split(".")[1],
+                f"[blue]{listener.address[0]}[/blue]:[cyan]{listener.address[1]}[/cyan]",
+                str(listener.platform),
+                count,
+                str(listener.pending),
+            )
+
+        console.print(table)

--- a/pwncat/manager.py
+++ b/pwncat/manager.py
@@ -240,6 +240,13 @@ class Listener(threading.Thread):
             if self.count is not None and self.count <= 0:
                 raise ListenerError("listener max connections reached")
 
+            if (
+                self.manager.target is not None
+                and self.manager.target.platform.interactive
+            ):
+                # Throw a newline out there to clear up the output a bit
+                print("\r", end="\n")
+
             if platform is None:
                 # We can't initialize this channel, so we just throw it on the queue
                 self._channel_queue.put_nowait(channel)
@@ -250,7 +257,9 @@ class Listener(threading.Thread):
 
             try:
                 session = self.manager.create_session(
-                    platform=platform, channel=channel
+                    platform=platform,
+                    channel=channel,
+                    active=False,
                 )
 
                 self.manager.log(

--- a/pwncat/manager.py
+++ b/pwncat/manager.py
@@ -272,6 +272,8 @@ class Listener(threading.Thread):
         to trip up the manager, as this is running in a background thread."""
 
         try:
+            raw_server = None
+            server = None
 
             # Start the listener and wrap in the SSL context
             raw_server = self._open_socket()

--- a/pwncat/manager.py
+++ b/pwncat/manager.py
@@ -13,6 +13,15 @@ even if there was an uncaught exception. The normal method of creating a manager
         # or open a connection
         session = manager.create_session(platform="linux", host="192.168.1.1", port=4444)
 
+Listeners
+---------
+
+The pwncat manager provides the ability to create background listeners. Background
+listeners are classes which inherit from :class:`threading.Thread`. To create a new
+listener, you can use the :func:`pwncat.manager.Manager.create_listener` method. To
+get an asynchronous notification of new sessions, you can use the ``established``
+callback which receives the new session as an argument.
+
 """
 import os
 import ssl
@@ -76,9 +85,27 @@ class ListenerState(Enum):
 
 
 class Listener(threading.Thread):
-    """Background Listener which acts a factory constructing sessions
+    """Background Listener which acts as a factory constructing sessions
     in the background. Listeners should not be created directly. Rather,
-    you should use the ``Manager.create_listener`` method.
+    you should use the :func:`pwncat.manager.Manager.create_listener` method.
+
+    .. code-block:: python
+        :caption: Using a background listener
+
+        def new_session(session: pwncat.manager.Session):
+            # Returning false causes the session to be removed immediately
+            return True
+
+        with Manager() as manager:
+            listener = manager.create_listener(
+                port=4444,
+                platform="linux",
+                ssl=True,
+                established=new_session,
+            )
+            # You can also stop the listener
+            # listener.stop()
+            manager.interactive()
     """
 
     def __init__(

--- a/pwncat/platform/windows.py
+++ b/pwncat/platform/windows.py
@@ -849,10 +849,9 @@ function prompt {
                         self.session.manager.log(
                             "[yellow]warning[/yellow]: Ctrl-C does not work for windows targets"
                         )
-        except EOFError:
-            self.channel.send(b"\rexit\r")
-            self.channel.recvuntil(INTERACTIVE_END_MARKER)
-            raise pwncat.util.RawModeExit
+                except EOFError:
+                    self.channel.send(b"\rexit\r")
+                    interactive_complete.wait()
         finally:
             pwncat.util.pop_term_state()
 

--- a/pwncat/platform/windows.py
+++ b/pwncat/platform/windows.py
@@ -852,6 +852,9 @@ function prompt {
                 except EOFError:
                     self.channel.send(b"\rexit\r")
                     interactive_complete.wait()
+        except KeyboardInterrupt:
+            # This should only happen during an EOFError above
+            pass
         finally:
             pwncat.util.pop_term_state()
 

--- a/test.py
+++ b/test.py
@@ -29,5 +29,6 @@ with pwncat.manager.Manager("data/pwncatrc") as manager:
     listener = manager.create_listener(
         protocol="socket", host="0.0.0.0", port=4444, platform="windows"
     )
+    listener = manager.create_listener(protocol="socket", host="0.0.0.0", port=9999)
 
     manager.interactive()

--- a/test.py
+++ b/test.py
@@ -20,10 +20,14 @@ with pwncat.manager.Manager("data/pwncatrc") as manager:
     # session = manager.create_session("windows", host="192.168.122.11", port=4444)
     # session = manager.create_session("linux", host="pwncat-ubuntu", port=4444)
     # session = manager.create_session("linux", host="127.0.0.1", port=4444)
-    session = manager.create_session(
-        "linux", certfile="/tmp/cert.pem", keyfile="/tmp/cert.pem", port=4444
-    )
+    # session = manager.create_session(
+    #     "linux", certfile="/tmp/cert.pem", keyfile="/tmp/cert.pem", port=4444
+    # )
 
     # session.platform.powershell("amsiutils")
+
+    listener = manager.create_listener(
+        protocol="socket", host="0.0.0.0", port=4444, platform="windows"
+    )
 
     manager.interactive()


### PR DESCRIPTION
## Description of Changes

Fixes #43.

The following are some design goals I have:

- [x] Stable and abstract API for interacting with listeners
- [x] Callback methods for sessions being established
- [x] Support for abstract listeners which queue uninitialized channels, and waits for the user to specify the platform on a per-connection basis.
- [x] Support for explicit platforms which allows the user to specify that all connections should be assumed to have `XYZ` platform and automatically create sessions.
- [x] View listeners state
- [x] Automatically stop listeners after a certain number of connections
- [x] Ignore connections from clients which already have an active session (identified after session establishment using host hash)

I have the above working now, and with some more testing, I'll move this from a draft state to ready for review.

## API Description

The `Manager` class now has a method named `create_listener`. A listener is a thread which maintains a raw socket listener (optionally wrapped in an SSL context). When a new connection is received, it uses the protocol specified during creation to construct a pwncat `Channel`. This must be a protocol which accepts a single `client` argument which is an open socket. Currently, the only protocol that supports this is `socket`. 

Once the channel is established, the listener will check if a platform was assigned at creation. If it was, a full session is established using the specified platform and the new channel, and the `established` callback is called. If the established callback returns `True`, the connection is kept, and the listener moves on. If it returns `False`, the listener closes the new session.

If no `platform` was provided, the new channel is added to a queue of pending channels, which can be retrieved through `listener.iter_channels()`. Once, the user knows the platform they'd like to use, they can call `listener.bootstrap_session(channel, platform_name)` to construct the final session and trigger the `established` callback.

```py
import pwncat.manager

with pwncat.manager.Manager() as manager:
    listener = manager.create_listener(platform="linux", port=4444, ssl=True, established=callback)

    manager.interactive()
```

## Local Prompt Interface

Two new commands were added: `listen` and `listeners`. The former creates new listeners while the latter manages active, stopped or failed listeners. Stopped and failed listeners are not removed from the list, and continue to be tracked in a stopped state. See the `--help` for these commands for more information, but here's a quick rundown:

```sh
# SSL listener for linux platforms, drop session matching existing host and user combos
# which will automatically stop after 4 successful sessions
listen --ssl --platform "linux" --drop-duplicate --count 4 9999
# Same as above
listen --ssl -m linux -D -c 4 9999
# Listener with no platform, new channels are queued for initialization
listen 9999
# List listeners and their IDs
listeners
# List listeners including stopped listeners
listeners --all
listeners -a
# Initialize pending channels on listener 1
listeners --init 1
# Stop/kill a listener
listeners -k 1
# Print all settings for listener 1
listeners 1
```

## Screenshots

![image](https://user-images.githubusercontent.com/7529189/122658377-6d7aba00-d13a-11eb-827b-7534ff2b96e9.png)

**Please note any `noqa:` comments needed to appease flake8.**

## Major Changes Implemented:
- Add background listener API to manager
- Add `listen` and `listener` commands

## Pre-Merge Tasks
- [x] Add API and command documentation
- [x] Formatted all modified files w/ `python-black`
- [x] Sorted imports for modified files w/ `isort`
- [x] Ran `flake8` on repo, and fixed any new problems w/ modified files
- [x] Ran `pytest` test cases
- [x] Added brief summary of updates to CHANGELOG (under `[Unreleased]`)

**For issues with pre-merge tasks, see CONTRIBUTING.md**