### PR TITLE
added gitattributes to hide powershell from language statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+pwncat/data/PowerSploit/** linguist-vendored


### PR DESCRIPTION
## Description of Changes

No major changes here. Added a `.gitattributes` file which should remove the powershell language statistics from the project on Github. For reference, I got the info for how to do this from [here](https://github.com/github/linguist/blob/master/docs/overrides.md).