### PR TITLE
[FIXED #156] Raised exception on using 'sessions'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and simply didn't have the time to go back and retroactively create one.
 ### Fixed
 - Possible exception due to _pre-registering_ of 'session' with 'manager'
 ### Added
-- Added an exception handler to allow use of 'C-c' during __create_____session__
+- Added an exception handler to allow use of 'C-c' during __create_session__
 - Added alternatives to `bash`, for _better shell_
 
 ## [0.4.3] - 2021-06-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The Changelog starts with v0.4.1, because we did not keep one before that,
 and simply didn't have the time to go back and retroactively create one.
 
 ## [Unreleased]
+### Fixed
+- Possible exception due to _pre-registering_ of 'session' with 'manager'
+### Added
+- Added an exception handler to allow use of 'C-c' during __create_____session__
+- Added alternatives to `bash`, for _better shell_
 
 ## [0.4.3] - 2021-06-18
 Patch fix release. Major fixes are the correction of file IO for LinuxWriters and

--- a/pwncat/__main__.py
+++ b/pwncat/__main__.py
@@ -280,7 +280,6 @@ def main():
                 except KeyboardInterrupt:
                     manager.log("[yellow]warning:[/yellow] cancelled by user")
 
-
         manager.interactive()
 
         if manager.sessions:

--- a/pwncat/__main__.py
+++ b/pwncat/__main__.py
@@ -277,6 +277,9 @@ def main():
                     )
                 except (ChannelError, PlatformError) as exc:
                     manager.log(f"connection failed: {exc}")
+                except KeyboardInterrupt:
+                    manager.log("[yellow]warning:[/yellow] cancelled by user")
+
 
         manager.interactive()
 

--- a/pwncat/channel/__init__.py
+++ b/pwncat/channel/__init__.py
@@ -73,7 +73,7 @@ class ChannelTimeout(ChannelError):
     """
 
     def __init__(self, ch, data: bytes):
-        super().__init__(ch, f"channel recieve timed out: {repr(data)}")
+        super().__init__(ch, f"channel receive timed out: {repr(data)}")
         self.data: bytes = data
 
 
@@ -394,7 +394,7 @@ class Channel(ABC):
         return data
 
     def recvline(self, timeout: Optional[float] = None) -> bytes:
-        """Recieve data until a newline is received. The newline
+        """Receive data until a newline is received. The newline
         is not stripped. This is a default implementation that
         utilizes the ``recvuntil`` method.
 

--- a/pwncat/manager.py
+++ b/pwncat/manager.py
@@ -89,10 +89,6 @@ class Session:
                 verbose=self.config.get("verbose", False),
             )
 
-        # Register this session with the manager
-        self.manager.sessions[self.id] = self
-        self.manager.target = self
-
         # Initialize the host reference
         self.hash = self.platform.get_host_hash()
 
@@ -102,6 +98,12 @@ class Session:
             self.log("loaded known host from db")
 
         self.platform.get_pty()
+
+        # Register this session with the manager
+        # some of the methods used above can raise an exception
+        # and we will register this session only when everything goes well
+        self.manager.sessions[self.id] = self
+        self.manager.target = self
 
     @property
     def config(self):

--- a/pwncat/platform/linux.py
+++ b/pwncat/platform/linux.py
@@ -611,7 +611,7 @@ class Linux(Platform):
 
         if os.path.basename(self.shell) in ["sh", "dash"]:
             # Try to find a better shell
-            # a custom `pwncat shell promt` may not be available for all the shells
+            # a custom `pwncat shell prompt` may not be available for all shells
             # see `self.PROMPTS`
             better_shells = ["bash", "zsh", "ksh", "fish"]
 

--- a/pwncat/platform/linux.py
+++ b/pwncat/platform/linux.py
@@ -611,12 +611,19 @@ class Linux(Platform):
 
         if os.path.basename(self.shell) in ["sh", "dash"]:
             # Try to find a better shell
-            bash = self._do_which("bash")
-            if bash is not None:
-                self.session.log(f"upgrading from {self.shell} to {bash}")
-                self.shell = bash
-                self.channel.sendline(f"exec {self.shell}".encode("utf-8"))
-                time.sleep(0.5)
+            # a custom `pwncat shell promt` may not be available for all the shells
+            # see `self.PROMPTS`
+            better_shells = ["bash", "zsh", "ksh", "fish"]
+
+            for better_shell in better_shells:
+                shell = self._do_which(better_shell)
+
+                if shell is not None:
+                    self.session.log(f"upgrading from {self.shell} to {shell}")
+                    self.shell = shell
+                    self.channel.sendline(f"exec {self.shell}".encode("utf-8"))
+                    time.sleep(0.5)
+                    break
 
         self.refresh_uid()
 

--- a/pwncat/platform/windows.py
+++ b/pwncat/platform/windows.py
@@ -20,7 +20,6 @@ import stat
 import time
 import base64
 import shutil
-import signal
 import hashlib
 import pathlib
 import tarfile

--- a/pwncat/platform/windows.py
+++ b/pwncat/platform/windows.py
@@ -620,7 +620,7 @@ function prompt {
         """This routine upgrades a standard powershell or cmd shell to an
         instance of the pwncat stage two C2. It will first locate a valid
         writable temporary directory (from the list below) and then upload
-        stage one to that directory. Stage one is a simple DLL which recieves
+        stage one to that directory. Stage one is a simple DLL which receives
         a base64 encoded, gzipped payload to reflectively load and execute.
         We run stage one using Install-Util to bypass applocker."""
 

--- a/pwncat/subprocess.py
+++ b/pwncat/subprocess.py
@@ -9,7 +9,7 @@ subprocess module.
     Depending on the platform you are connected to, you may only be
     able to run a single process at a time. Because of this, you
     should always ensure the process properly exits and you call
-    ``Popen.wait()`` or recieve a non-None result from ``Popen.poll()``
+    ``Popen.wait()`` or receive a non-None result from ``Popen.poll()``
     before calling other pwncat methods.
 
 """


### PR DESCRIPTION
## Description of Changes
Fixes #156
There was a `flake8` warning about an unused import, see https://github.com/Mitul16/pwncat/commit/161a5769a28af292487ca8ad1db84133efba6bfc

## Major Changes Implemented:
- Fixed a possible exception due to _pre-registering_ of 'session' with 'manager'
- Added exception handler to allow the use of 'C-c' during __create_session__
- Added alternatives to `bash`, for _better shell_

## Pre-Merge Tasks
- [x] Formatted all modified files w/ `python-black`
- [x] Sorted imports for modified files w/ `isort`
- [x] Ran `flake8` on repo, and fixed any new problems w/ modified files
- [x] Ran `pytest` test cases
- [x] Added brief summary of updates to CHANGELOG (under `[Unreleased]`)
