### PR TITLE
[FIXED #156] Raised exception on using 'sessions'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and simply didn't have the time to go back and retroactively create one.
 
 ## [Unreleased]
 
+### Fixed
+- Possible exception due to _pre-registering_ of `session` with `manager`
+### Added
+- Added alternatives to `bash` to be used during _shell upgrade_ for a _better shell_
+- Added a warning message when a `KeyboardInterrupt` is caught
+### Changed
+- Changed some 'red' warning message color to 'yellow'
+
 ## [0.4.3] - 2021-06-18
 Patch fix release. Major fixes are the correction of file IO for LinuxWriters and
 improved stability with better exception handling.

--- a/pwncat/__main__.py
+++ b/pwncat/__main__.py
@@ -279,7 +279,7 @@ def main():
                     manager.log(f"connection failed: {exc}")
                 except KeyboardInterrupt:
                     # hide '^C' from the output
-                    sys.stdout.write('\b\b\r')
+                    sys.stdout.write("\b\b\r")
                     manager.log("[yellow]warning[/yellow]: cancelled by user")
 
         manager.interactive()

--- a/pwncat/__main__.py
+++ b/pwncat/__main__.py
@@ -278,6 +278,8 @@ def main():
                 except (ChannelError, PlatformError) as exc:
                     manager.log(f"connection failed: {exc}")
                 except KeyboardInterrupt:
+                    # hide '^C' from the output
+                    sys.stdout.write('\b\b\r')
                     manager.log("[yellow]warning[/yellow]: cancelled by user")
 
         manager.interactive()

--- a/pwncat/__main__.py
+++ b/pwncat/__main__.py
@@ -277,6 +277,8 @@ def main():
                     )
                 except (ChannelError, PlatformError) as exc:
                     manager.log(f"connection failed: {exc}")
+                except KeyboardInterrupt:
+                    manager.log("[yellow]warning[/yellow]: cancelled by user")
 
         manager.interactive()
 

--- a/pwncat/channel/__init__.py
+++ b/pwncat/channel/__init__.py
@@ -73,7 +73,7 @@ class ChannelTimeout(ChannelError):
     """
 
     def __init__(self, ch, data: bytes):
-        super().__init__(ch, f"channel recieve timed out: {repr(data)}")
+        super().__init__(ch, f"channel receive timed out: {repr(data)}")
         self.data: bytes = data
 
 
@@ -394,7 +394,7 @@ class Channel(ABC):
         return data
 
     def recvline(self, timeout: Optional[float] = None) -> bytes:
-        """Recieve data until a newline is received. The newline
+        """Receive data until a newline is received. The newline
         is not stripped. This is a default implementation that
         utilizes the ``recvuntil`` method.
 

--- a/pwncat/channel/connect.py
+++ b/pwncat/channel/connect.py
@@ -48,9 +48,11 @@ class Connect(Socket):
             try:
                 client = socket.create_connection((host, port))
             except socket.gaierror:
-                raise ChannelError(self, "invalid host provided")
+                raise ChannelError(self, "unable to resolve host")
             except ConnectionRefusedError:
                 raise ChannelError(self, "connection refused, check your port")
+            except OSError:
+                raise ChannelError(self, "invalid host provided")
 
             progress.log(
                 f"connection to "

--- a/pwncat/commands/__init__.py
+++ b/pwncat/commands/__init__.py
@@ -523,7 +523,9 @@ class CommandParser:
                 self.dispatch_line(command)
             except ChannelClosed as exc:
                 # A channel was unexpectedly closed
-                self.manager.log(f"[yellow]warning[/yellow]: {exc.channel}: channel closed")
+                self.manager.log(
+                    f"[yellow]warning[/yellow]: {exc.channel}: channel closed"
+                )
                 # Ensure any existing sessions are cleaned from the manager
                 exc.cleanup(self.manager)
             except pwncat.manager.InteractiveExit:
@@ -593,7 +595,9 @@ class CommandParser:
                 continue
             except ChannelClosed as exc:
                 # A channel was unexpectedly closed
-                self.manager.log(f"[yellow]warning[/yellow]: {exc.channel}: channel closed")
+                self.manager.log(
+                    f"[yellow]warning[/yellow]: {exc.channel}: channel closed"
+                )
                 # Ensure any existing sessions are cleaned from the manager
                 exc.cleanup(self.manager)
             except pwncat.manager.InteractiveExit:

--- a/pwncat/commands/__init__.py
+++ b/pwncat/commands/__init__.py
@@ -523,7 +523,7 @@ class CommandParser:
                 self.dispatch_line(command)
             except ChannelClosed as exc:
                 # A channel was unexpectedly closed
-                self.manager.log(f"[red]warning[/red]: {exc.channel}: channel closed")
+                self.manager.log(f"[yellow]warning[/yellow]: {exc.channel}: channel closed")
                 # Ensure any existing sessions are cleaned from the manager
                 exc.cleanup(self.manager)
             except pwncat.manager.InteractiveExit:
@@ -593,7 +593,7 @@ class CommandParser:
                 continue
             except ChannelClosed as exc:
                 # A channel was unexpectedly closed
-                self.manager.log(f"[red]warning[/red]: {exc.channel}: channel closed")
+                self.manager.log(f"[yellow]warning[/yellow]: {exc.channel}: channel closed")
                 # Ensure any existing sessions are cleaned from the manager
                 exc.cleanup(self.manager)
             except pwncat.manager.InteractiveExit:

--- a/pwncat/commands/connect.py
+++ b/pwncat/commands/connect.py
@@ -244,3 +244,5 @@ class Command(CommandDefinition):
                 )
             except (ChannelError, PlatformError) as exc:
                 manager.log(f"connection failed: {exc}")
+            except KeyboardInterrupt:
+                manager.log("[yellow]warning[/yellow]: cancelled by user")

--- a/pwncat/commands/connect.py
+++ b/pwncat/commands/connect.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import re
+import sys
 
 from rich import box
 from rich.table import Table
@@ -245,4 +246,6 @@ class Command(CommandDefinition):
             except (ChannelError, PlatformError) as exc:
                 manager.log(f"connection failed: {exc}")
             except KeyboardInterrupt:
+                # hide '^C' from the output
+                sys.stdout.write('\b\b\r')
                 manager.log("[yellow]warning[/yellow]: cancelled by user")

--- a/pwncat/commands/connect.py
+++ b/pwncat/commands/connect.py
@@ -247,5 +247,5 @@ class Command(CommandDefinition):
                 manager.log(f"connection failed: {exc}")
             except KeyboardInterrupt:
                 # hide '^C' from the output
-                sys.stdout.write('\b\b\r')
+                sys.stdout.write("\b\b\r")
                 manager.log("[yellow]warning[/yellow]: cancelled by user")

--- a/pwncat/manager.py
+++ b/pwncat/manager.py
@@ -89,10 +89,6 @@ class Session:
                 verbose=self.config.get("verbose", False),
             )
 
-        # Register this session with the manager
-        self.manager.sessions[self.id] = self
-        self.manager.target = self
-
         # Initialize the host reference
         self.hash = self.platform.get_host_hash()
 
@@ -102,6 +98,12 @@ class Session:
             self.log("loaded known host from db")
 
         self.platform.get_pty()
+
+        # Register this session with the manager
+        # some of the methods used above can raise an exception
+        # and we will register this session only when everything goes well
+        self.manager.sessions[self.id] = self
+        self.manager.target = self
 
     @property
     def config(self):

--- a/pwncat/platform/linux.py
+++ b/pwncat/platform/linux.py
@@ -611,12 +611,19 @@ class Linux(Platform):
 
         if os.path.basename(self.shell) in ["sh", "dash"]:
             # Try to find a better shell
-            bash = self._do_which("bash")
-            if bash is not None:
-                self.session.log(f"upgrading from {self.shell} to {bash}")
-                self.shell = bash
-                self.channel.sendline(f"exec {self.shell}".encode("utf-8"))
-                time.sleep(0.5)
+            # a custom `pwncat shell prompt` may not be available for all shells
+            # see `self.PROMPTS`
+            better_shells = ["bash", "zsh", "ksh", "fish"]
+
+            for better_shell in better_shells:
+                shell = self._do_which(better_shell)
+
+                if shell is not None:
+                    self.session.log(f"upgrading from {self.shell} to {shell}")
+                    self.shell = shell
+                    self.channel.sendline(f"exec {self.shell}".encode("utf-8"))
+                    time.sleep(0.5)
+                    break
 
         self.refresh_uid()
 

--- a/pwncat/platform/windows.py
+++ b/pwncat/platform/windows.py
@@ -20,7 +20,6 @@ import stat
 import time
 import base64
 import shutil
-import signal
 import hashlib
 import pathlib
 import tarfile

--- a/pwncat/platform/windows.py
+++ b/pwncat/platform/windows.py
@@ -620,7 +620,7 @@ function prompt {
         """This routine upgrades a standard powershell or cmd shell to an
         instance of the pwncat stage two C2. It will first locate a valid
         writable temporary directory (from the list below) and then upload
-        stage one to that directory. Stage one is a simple DLL which recieves
+        stage one to that directory. Stage one is a simple DLL which receives
         a base64 encoded, gzipped payload to reflectively load and execute.
         We run stage one using Install-Util to bypass applocker."""
 

--- a/pwncat/subprocess.py
+++ b/pwncat/subprocess.py
@@ -9,7 +9,7 @@ subprocess module.
     Depending on the platform you are connected to, you may only be
     able to run a single process at a time. Because of this, you
     should always ensure the process properly exits and you call
-    ``Popen.wait()`` or recieve a non-None result from ``Popen.poll()``
+    ``Popen.wait()`` or receive a non-None result from ``Popen.poll()``
     before calling other pwncat methods.
 
 """


### PR DESCRIPTION
## Description of Changes
Fixes #156
There was a `flake8` warning about an unused import, see https://github.com/Mitul16/pwncat/commit/a4cee5be27427d528b8a3e849f83c020dae6945b

Sorry for closing my last __PR__, there was one incorrect commit and some redundant commits added later.
I wanted to keep it all clean :sweat_smile: 

There is just _one difference_ in this __PR__, see https://github.com/Mitul16/pwncat/commit/b511a37f71e7c8f722b70ab3d030d7c70d7f8c7d
I have changed the error messages in `pwncat/channel/connect.py` so that they show the correct message.

## Major Changes Implemented:
- Fixed a possible exception due to _pre-registering_ of `session` with `manager`
- Added alternatives to `bash` to be used during _shell upgrade_ for a _better shell_
- Added a warning message when a `KeyboardInterrupt` is caught
- Changed some 'red' warning message color to 'yellow'

## Pre-Merge Tasks
- [x] Formatted all modified files w/ `python-black`
- [x] Sorted imports for modified files w/ `isort`
- [x] Ran `flake8` on repo, and fixed any new problems w/ modified files
- [x] Ran `pytest` test cases
- [x] Added brief summary of updates to CHANGELOG (under `[Unreleased]`)
