### PR TITLE
[FIXES 159] Correctly handle IPv6 Sockets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and simply didn't have the time to go back and retroactively create one.
 
 ### Fixed
 - Possible exception due to _pre-registering_ of `session` with `manager`
+- Fixed handling of `socket.getpeername` when `Socket` channel uses IPv6 ([#159](https://github.com/calebstewart/pwncat/issues/159)).
 ### Added
 - Added alternatives to `bash` to be used during _shell upgrade_ for a _better shell_
 - Added a warning message when a `KeyboardInterrupt` is caught

--- a/pwncat/channel/socket.py
+++ b/pwncat/channel/socket.py
@@ -50,7 +50,11 @@ class Socket(Channel):
 
         if client is not None:
             # Report host and port number to base channel
-            host, port = client.getpeername()
+            host, port, *_ = client.getpeername()
+
+            # Localhost is sometimes a IPv4 and sometimes IPv6 socket, just normalize the name
+            if host == "::1" or host == "127.0.0.1":
+                host = "localhost"
 
             if "host" not in kwargs:
                 kwargs["host"] = host
@@ -77,6 +81,10 @@ class Socket(Channel):
         self._connected = True
         self.client = client
         self.address = client.getpeername()
+
+        # Localhost is sometimes a IPv4 and sometimes IPv6 socket, just normalize the name
+        if self.address[0] == "::1" or self.address[0] == "127.0.0.1":
+            self.address = ("localhost", *self.address[1:])
 
         self.client.setblocking(False)
         fcntl.fcntl(self.client, fcntl.F_SETFL, os.O_NONBLOCK)


### PR DESCRIPTION
## Description of Changes

The `Socket` channel type did not handle the results of `socket.getpeername` for IPv6 sockets. These updates fix this, and also normalize the hostname for targets that result in either `::1` or `127.0.0.1` to simply `localhost`. This is mostly cosmetic, but I think it reads nicer in the pwncat output and seemed relatively relevant to this fix.

Fixes #159.

## Major Changes Implemented:
- Ignored extra data in result from `socket.getpeername` when using IPv6
- Translated both `::1` and `127.0.0.1` to the hostname `localhost` for clearer output

## Pre-Merge Tasks
- [x] Formatted all modified files w/ `python-black`
- [x] Sorted imports for modified files w/ `isort`
- [x] Ran `flake8` on repo, and fixed any new problems w/ modified files
- [x] Ran `pytest` test cases
- [x] Added brief summary of updates to CHANGELOG (under `[Unreleased]`)

**For issues with pre-merge tasks, see CONTRIBUTING.md**

<!--
If you are submitting a pull request for a new module, the following
information is also helpful:

## Platform and Environment Restrictions
(e.g. "Windows targets without HOTFIX XXXXXX")

## Full Qualified Module Name
(e.g. "linux.enumerate.system.network")

## Artifacts Generated
(e.g. "creates file at /etc/something.ini tracked w/ a tamper")

## Tested Targets
(e.g. "Tested on Windows 10 1604")
-->
