### PR TITLE
Correct password processing in connection string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ improved stability with better exception handling.
 - Pinned container base image to alpine 3.13.5 and installed to virtualenv ([#134](https://github.com/calebstewart/pwncat/issues/134))
 - Fixed syntax for f-strings in escalation command
 - Re-added `readline` import for windows platform after being accidentally removed
+- Corrected processing of password in connection string
 ### Changed
 - Changed session tracking so session IDs aren't reused
 - Changed zsh prompt to match CWD of other shell prompts

--- a/pwncat/__main__.py
+++ b/pwncat/__main__.py
@@ -163,6 +163,9 @@ def main():
                 host = m.group("host")
                 port = m.group("port")
 
+                if password is not None:
+                    password = password.removeprefix(":")
+
             if protocol is not None:
                 protocol = protocol.removesuffix("://")
 

--- a/pwncat/commands/connect.py
+++ b/pwncat/commands/connect.py
@@ -137,6 +137,9 @@ class Command(CommandDefinition):
             host = m.group("host")
             port = m.group("port")
 
+            if password is not None:
+                password = password.removeprefix(":")
+
         if protocol is not None:
             protocol = protocol.removesuffix("://")
 


### PR DESCRIPTION
## Description of Changes
When processing the connection string for the `connect` command and the entrypoint, the `:` was not stripped from a password. This branch correctly strings the leading colon when a password is passed like: `ssh://user:password@host`.

## Major Changes Implemented:
- Corrected password processing in connection string

## Pre-Merge Tasks
- [x] Formatted all modified files w/ `python-black`
- [x] Sorted imports for modified files w/ `isort`
- [x] Ran `flake8` on repo, and fixed any new problems w/ modified files
- [x] Ran `pytest` test cases
- [x] Added brief summary of updates to CHANGELOG (under `[Unreleased]`)

**For issues with pre-merge tasks, see CONTRIBUTING.md**

<!--
If you are submitting a pull request for a new module, the following
information is also helpful:

## Platform and Environment Restrictions
(e.g. "Windows targets without HOTFIX XXXXXX")

## Full Qualified Module Name
(e.g. "linux.enumerate.system.network")

## Artifacts Generated
(e.g. "creates file at /etc/something.ini tracked w/ a tamper")

## Tested Targets
(e.g. "Tested on Windows 10 1604")
-->
