### PR TITLE
[FIXES 169] Python version issue in docker build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and simply didn't have the time to go back and retroactively create one.
 
 ### Fixed
 - Possible exception due to _pre-registering_ of `session` with `manager`
+- Updated Dockerfile to use __alpine:3.14__ for __python3.9__ and updated `setup.py` script
 ### Added
 - Added alternatives to `bash` to be used during _shell upgrade_ for a _better shell_
 - Added a warning message when a `KeyboardInterrupt` is caught

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.13.5 as builder
+FROM alpine:3.14 as builder
 
 # Install python3 and development files
 RUN set -eux \
@@ -32,7 +32,7 @@ RUN set -eux \
 	&& find /opt/pwncat/lib -type d -name '__pycache__' -print0 | xargs -0 -n1 rm -rf || true
 
 
-FROM alpine:3.13.5 as final
+FROM alpine:3.14 as final
 
 RUN set -eux \
 	&& apk add --no-cache \

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ be observed with your installed package.
 
 The setup script will install three binaries. They are all identical, but
 provide convenience aliases for pwncat. The three binaries are: `pwncat`,
-`pc` and `pcat`.
+`pc`.
 
 ### Connecting to a Victim
 
@@ -196,6 +196,10 @@ is the `pwncat` binary. It can be used like so:
 ``` shell
 # Connect to a bind shell at 10.0.0.1:4444
 docker run -v "/some/directory":/work -t pwncat 10.0.0.1 4444
+
+# If you face any issues related to Cursor Position Requests (CPR)
+# Run the docker container in interactive mode using `-i/--interactive`
+docker run -v "/some/directory":/work -t --interactive pwncat 10.0.0.1 4444
 ```
 
 In this example, only the files in `/some/directory` are exposed to the container.

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ dependency_links = []
 setup(
     name="pwncat",
     version="0.4.3",
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     description="A fancy reverse and bind shell handler",
     author="Caleb Stewart",
     url="https://gitlab.com/calebstewart/pwncat",


### PR DESCRIPTION
## Description of Changes

Fixes #169

## Major Changes Implemented:
- fix for python version: 3.9

## Pre-Merge Tasks
- [x] Formatted all modified files w/ `python-black`
- [x] Sorted imports for modified files w/ `isort`
- [x] Ran `flake8` on repo, and fixed any new problems w/ modified files
- [x] Ran `pytest` test cases
- [x] Added brief summary of updates to CHANGELOG (under `[Unreleased]`)