### PR TITLE
Home directory prefix support

### DIFF
--- a/pwncat/commands/upload.py
+++ b/pwncat/commands/upload.py
@@ -13,7 +13,7 @@ from rich.progress import (
 
 import pwncat
 from pwncat.util import console, copyfileobj, human_readable_size, human_readable_delta
-from pwncat.commands import Complete, Parameter, CommandDefinition
+from pwncat.commands import Complete, Parameter, ParseType, CommandDefinition
 
 
 class Command(CommandDefinition):
@@ -21,7 +21,7 @@ class Command(CommandDefinition):
 
     PROG = "upload"
     ARGS = {
-        "source": Parameter(Complete.LOCAL_FILE),
+        "source": Parameter(Complete.LOCAL_FILE, parser=ParseType.LOCAL_FILE),
         "destination": Parameter(
             Complete.REMOTE_FILE,
             nargs="?",


### PR DESCRIPTION
## Description of Changes

Ran into an issue where `upload ~/file.txt /tmp/file.txt` error-ed out on me. Looking into this, I found pwncat doesn't support the home directory prefix.

This is just a possible fix I've come up with, I'd love to hear feedback on these changes and if you think I'm heading into the right direction.

The way I've currently done this would also be able to allow for other prefixes to be configured for pwncat at some point. I can imagine wanting to have a prefix like `@` for where I've stored my static binaries.

## Major Changes Implemented:
- Introduces parameter parsers
- Added home directory (`~`) support

## Pre-Merge Tasks
- [x] Formatted all modified files w/ `python-black`
- [x] Sorted imports for modified files w/ `isort`
- [x] Ran `flake8` on repo, and fixed any new problems w/ modified files
- [x] Ran `pytest` test cases
- [x] Added brief summary of updates to CHANGELOG (under `[Unreleased]`)
