### PR TITLE
Updated leak_privkey to leak all keys when UID=0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and simply didn't have the time to go back and retroactively create one.
 - Added a warning message when a `KeyboardInterrupt` is caught
 ### Changed
 - Changed some 'red' warning message color to 'yellow'
+- Leak private keys for all users w/ file-read ability as UID=0 ([#181](https://github.com/calebstewart/pwncat/issues/181))
+- Raise `PermissionError` when underlying processes terminate unsuccessfully for `LinuxReader` and `LinuxWriter`
 
 ## [0.4.3] - 2021-06-18
 Patch fix release. Major fixes are the correction of file IO for LinuxWriters and

--- a/pwncat/platform/linux.py
+++ b/pwncat/platform/linux.py
@@ -343,6 +343,12 @@ class LinuxReader(BufferedIOBase):
             self.popen.terminate()
             self.popen.wait()
 
+        # This happens immediately upon the first read attempt because the process will have
+        # exited. During testing, this seems reliable. It's not ideal, but we don't know what
+        # the remote process is...
+        if self.popen.returncode != 0:
+            raise PermissionError(self.name)
+
         self.detach()
 
 
@@ -483,6 +489,12 @@ class LinuxWriter(BufferedIOBase):
             # at least attempt to do whatever cleanup we can.
             self.popen.kill()
             self.popen.wait()
+
+        # This happens immediately upon the first read attempt because the process will have
+        # exited. During testing, this seems reliable. It's not ideal, but we don't know what
+        # the remote process is...
+        if self.popen.returncode != 0:
+            raise PermissionError(self.name)
 
         # Ensure we don't touch stdio again
         self.detach()


### PR DESCRIPTION
## Description of Changes

Fixes #181. This fix will make the `enumerate.escalate.leak_privkey` module leak keys for all users when we detect a file-read ability for `UID=0`. 

I have also added an exception to the `LinuxReader` and `LinuxWriter` classes. If the underlying process exits with a non-zero exit code, the close method will raise a `PermissionError`. In *most* cases, this is the correct behavior. In cases where we *can* check before hand, we do. In the case of privilege escalation, we often can't test the permissions of the files we are attempting to access, and therefore defaulting to a `PermissionError` seems logical.

## Major Changes Implemented:
- Leak private keys for all users w/ file-read ability as UID=0 ([#181](https://github.com/calebstewart/pwncat/issues/181))
- Raise `PermissionError` when underlying processes terminate unsuccessfully for `LinuxReader` and `LinuxWriter`

## Pre-Merge Tasks
- [x] Formatted all modified files w/ `python-black`
- [x] Sorted imports for modified files w/ `isort`
- [x] Ran `flake8` on repo, and fixed any new problems w/ modified files
- [x] Ran `pytest` test cases
- [x] Added brief summary of updates to CHANGELOG (under `[Unreleased]`)

**For issues with pre-merge tasks, see CONTRIBUTING.md**

<!--
If you are submitting a pull request for a new module, the following
information is also helpful:

## Platform and Environment Restrictions
(e.g. "Windows targets without HOTFIX XXXXXX")

## Full Qualified Module Name
(e.g. "linux.enumerate.system.network")

## Artifacts Generated
(e.g. "creates file at /etc/something.ini tracked w/ a tamper")

## Tested Targets
(e.g. "Tested on Windows 10 1604")
-->
