### PR TITLE
Fixed sudo rule parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and simply didn't have the time to go back and retroactively create one.
 
 ### Fixed
 - Possible exception due to _pre-registering_ of `session` with `manager`
+- Covered edge case in sudo rule parsing for wildcards ([#183](https://github.com/calebstewart/pwncat/issue/183))
+- Added fallthrough cases for PTY methods in case of misbehaving binaries (looking at you: `screen`)
 ### Added
 - Added alternatives to `bash` to be used during _shell upgrade_ for a _better shell_
 - Added a warning message when a `KeyboardInterrupt` is caught

--- a/pwncat/gtfobins.py
+++ b/pwncat/gtfobins.py
@@ -121,6 +121,9 @@ class Method:
         elif spec[-1] == "*":
             has_wildcard = True
             command = spec.rstrip("*")
+        else:
+            has_wildcard = False
+            command = spec
 
         # The sudo command is just "/path/to/binary", we are allowed to add any
         # parameters we want.


### PR DESCRIPTION
## Description of Changes

Fixes #183. There was a fallthrough case not handled in the sudo rule parsing related to wildcard characters in the sudo rules. I corrected this deficiency, and the enumeration seems to be working on the reported target in issue #183.

**Please note any `noqa:` comments needed to appease flake8.**

## Major Changes Implemented:
- Covered edge case in sudo rule parsing for wildcards ([#183](https://github.com/calebstewart/pwncat/issue/183))
- Added fallthrough cases for PTY methods in case of misbehaving binaries (looking at you: `screen`)

## Pre-Merge Tasks
- [x] Formatted all modified files w/ `python-black`
- [x] Sorted imports for modified files w/ `isort`
- [x] Ran `flake8` on repo, and fixed any new problems w/ modified files
- [x] Ran `pytest` test cases
- [x] Added brief summary of updates to CHANGELOG (under `[Unreleased]`)

**For issues with pre-merge tasks, see CONTRIBUTING.md**

<!--
If you are submitting a pull request for a new module, the following
information is also helpful:

## Platform and Environment Restrictions
(e.g. "Windows targets without HOTFIX XXXXXX")

## Full Qualified Module Name
(e.g. "linux.enumerate.system.network")

## Artifacts Generated
(e.g. "creates file at /etc/something.ini tracked w/ a tamper")

## Tested Targets
(e.g. "Tested on Windows 10 1604")
-->
