### PR TITLE
[FIX #169] Update docker base image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+data/
+.github/
+tests/
+docs/
+db/
+*.md
+*.txt
+*.sh
+test.py
+.flake8
+.gitattributes
+.gitignore
+.git/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and simply didn't have the time to go back and retroactively create one.
 - Fixed handling of `socket.getpeername` when `Socket` channel uses IPv6 ([#159](https://github.com/calebstewart/pwncat/issues/159)).
 - Fixed verbose logging handler to be __unique__ for every `channel`
 - Fixed docstrings in `Command` modules
+- Changed docker base image to `python3.9-alpine` to fix python version issues.
 ### Added
 - Added alternatives to `bash` to be used during _shell upgrade_ for a _better shell_
 - Added a warning message when a `KeyboardInterrupt` is caught


### PR DESCRIPTION
## Description of Changes

Fixes #169. I updated the docker file to depend on the `python3.9-alpine` image to fix Python version mismatches as detailed in that issue. I'm preferring this over the fix in #171 as discussed there. Basically, we used to depend on `alpine` directly and install python manually. That was problematic. This should be more consistent.

## Major Changes Implemented:
- Changed docker base image to `python3.9-alpine`

## Pre-Merge Tasks
- [x] Formatted all modified files w/ `python-black`
- [x] Sorted imports for modified files w/ `isort`
- [x] Ran `flake8` on repo, and fixed any new problems w/ modified files
- [x] Ran `pytest` test cases
- [x] Added brief summary of updates to CHANGELOG (under `[Unreleased]`)