### PR TITLE
[FIXES 185] Added logic for calling correct paramiko method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and simply didn't have the time to go back and retroactively create one.
 - Fixed verbose logging handler to be __unique__ for every `channel`
 - Fixed docstrings in `Command` modules
 - Changed docker base image to `python3.9-alpine` to fix python version issues.
+- Added logic for calling correct paramiko method when reloading an encrypted SSH privat ekey ([#185](https://github.com/calebstewart/issues/185)).
 ### Added
 - Added alternatives to `bash` to be used during _shell upgrade_ for a _better shell_
 - Added a warning message when a `KeyboardInterrupt` is caught

--- a/pwncat/channel/ssh.py
+++ b/pwncat/channel/ssh.py
@@ -65,7 +65,12 @@ class Ssh(Channel):
             except paramiko.ssh_exception.SSHException:
                 password = prompt("RSA Private Key Passphrase: ", is_password=True)
                 try:
-                    key = paramiko.RSAKey.from_private_key_file(identity, password)
+                    if isinstance(identity, str):
+                        key = paramiko.RSAKey.from_private_key_file(identity, password)
+                    else:
+                        # Seek back to the beginning of the file (the above load read the whole file)
+                        identity.seek(0)
+                        key = paramiko.RSAKey.from_private_key(identity, password)
                 except paramiko.ssh_exception.SSHException:
                     raise ChannelError(self, "invalid private key or passphrase")
 


### PR DESCRIPTION
## Description of Changes

Change the SSH channel implementation to call the correct paramiko method for loading a file path vs a file-like object when using an encrypted private key.

Fixes #185 

**Please note any `noqa:` comments needed to appease flake8.**

## Major Changes Implemented:
- Added logic for calling correct paramiko method when reloading an encrypted SSH private key

## Pre-Merge Tasks
- [x] Formatted all modified files w/ `python-black`
- [x] Sorted imports for modified files w/ `isort`
- [x] Ran `flake8` on repo, and fixed any new problems w/ modified files
- [x] Ran `pytest` test cases
- [x] Added brief summary of updates to CHANGELOG (under `[Unreleased]`)

**For issues with pre-merge tasks, see CONTRIBUTING.md**

<!--
If you are submitting a pull request for a new module, the following
information is also helpful:

## Platform and Environment Restrictions
(e.g. "Windows targets without HOTFIX XXXXXX")

## Full Qualified Module Name
(e.g. "linux.enumerate.system.network")

## Artifacts Generated
(e.g. "creates file at /etc/something.ini tracked w/ a tamper")

## Tested Targets
(e.g. "Tested on Windows 10 1604")
-->
