### PR TITLE
Forced Stream.RAW for gtfobins interactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and simply didn't have the time to go back and retroactively create one.
 - Fixed docstrings in `Command` modules
 - Changed docker base image to `python3.9-alpine` to fix python version issues.
 - Added logic for calling correct paramiko method when reloading an encrypted SSH privat ekey ([#185](https://github.com/calebstewart/issues/185)).
+- Forced `Stream.RAW` for all GTFOBins interaction ([#195](https://github.com/calebstewart/issues/195)).
 ### Added
 - Added alternatives to `bash` to be used during _shell upgrade_ for a _better shell_
 - Added a warning message when a `KeyboardInterrupt` is caught

--- a/pwncat/modules/linux/enumerate/file/suid.py
+++ b/pwncat/modules/linux/enumerate/file/suid.py
@@ -5,6 +5,7 @@ import rich.markup
 
 import pwncat
 from pwncat.db import Fact
+from pwncat.gtfobins import Stream
 from pwncat.facts.ability import build_gtfo_ability
 from pwncat.platform.linux import Linux
 from pwncat.modules.enumerate import Schedule, EnumerateModule
@@ -70,7 +71,9 @@ class Module(EnumerateModule):
                         build_gtfo_ability(
                             self.name, uid, method, source_uid=None, suid=True
                         )
-                        for method in session.platform.gtfo.iter_binary(path)
+                        for method in session.platform.gtfo.iter_binary(
+                            path, stream=Stream.RAW
+                        )
                     )
         finally:
             proc.wait()

--- a/pwncat/modules/linux/enumerate/software/sudo/cve_2019_14287.py
+++ b/pwncat/modules/linux/enumerate/software/sudo/cve_2019_14287.py
@@ -3,7 +3,7 @@ from packaging import version
 
 import pwncat
 from pwncat.facts import build_gtfo_ability
-from pwncat.gtfobins import Capability
+from pwncat.gtfobins import Stream, Capability
 from pwncat.platform.linux import Linux
 from pwncat.modules.enumerate import Schedule, EnumerateModule
 
@@ -64,7 +64,7 @@ class Module(EnumerateModule):
             if "ALL" in userlist and "!root" in userlist:
                 for command in rule.commands:
                     for method in session.platform.gtfo.iter_sudo(
-                        command, caps=Capability.ALL
+                        command, caps=Capability.ALL, stream=Stream.RAW
                     ):
                         # Build a generic GTFObins capability
                         yield build_gtfo_ability(

--- a/pwncat/modules/linux/enumerate/software/sudo/rules.py
+++ b/pwncat/modules/linux/enumerate/software/sudo/rules.py
@@ -6,6 +6,7 @@ import rich.markup
 
 from pwncat.db import Fact
 from pwncat.facts import build_gtfo_ability
+from pwncat.gtfobins import Stream
 from pwncat.platform.linux import Linux
 from pwncat.modules.enumerate import Schedule, EnumerateModule
 
@@ -238,7 +239,9 @@ class Module(EnumerateModule):
                                 source_uid=user.id,
                                 user=runas_user.name,
                             )
-                            for method in session.platform.gtfo.iter_sudo(spec)
+                            for method in session.platform.gtfo.iter_sudo(
+                                spec, stream=Stream.RAW
+                            )
                         )
 
                 return
@@ -304,5 +307,7 @@ class Module(EnumerateModule):
                         user=user.name,
                         source_uid=current_user.id,
                     )
-                    for method in session.platform.gtfo.iter_sudo(spec)
+                    for method in session.platform.gtfo.iter_sudo(
+                        spec, stream=Stream.RAW
+                    )
                 )

--- a/pwncat/platform/linux.py
+++ b/pwncat/platform/linux.py
@@ -1274,7 +1274,7 @@ class Linux(Platform):
         if "w" in mode:
 
             for method in self.gtfo.iter_methods(
-                caps=Capability.WRITE, stream=Stream.PRINT | Stream.RAW
+                caps=Capability.WRITE, stream=Stream.RAW
             ):
                 try:
                     payload, input_data, exit_cmd = method.build(
@@ -1303,7 +1303,7 @@ class Linux(Platform):
             )
         else:
             for method in self.gtfo.iter_methods(
-                caps=Capability.READ, stream=Stream.PRINT | Stream.RAW
+                caps=Capability.READ, stream=Stream.RAW
             ):
                 try:
                     payload, input_data, exit_cmd = method.build(


### PR DESCRIPTION
## Description of Changes

This pull request makes pwncat use only `Stream.RAW` gtfobins payloads for Linux platforms. This ensures that we don't pick up any remaining `base64` streams and also don't accidentally use a `Stream.PRINT` stream when writing/reading binary data.

This pull request only fixes small part of #195, but does not rectify the entire issue. A larger effort will be needed to close that issue.

## Major Changes Implemented:
- Forced `Stream.RAW` for GTFObins interactions

## Pre-Merge Tasks
- [x] Formatted all modified files w/ `python-black`
- [x] Sorted imports for modified files w/ `isort`
- [x] Ran `flake8` on repo, and fixed any new problems w/ modified files
- [x] Ran `pytest` test cases
- [x] Added brief summary of updates to CHANGELOG (under `[Unreleased]`)

<!--
If you are submitting a pull request for a new module, the following
information is also helpful:

## Platform and Environment Restrictions
(e.g. "Windows targets without HOTFIX XXXXXX")

## Full Qualified Module Name
(e.g. "linux.enumerate.system.network")

## Artifacts Generated
(e.g. "creates file at /etc/something.ini tracked w/ a tamper")

## Tested Targets
(e.g. "Tested on Windows 10 1604")
-->
