### PR TITLE
Added Linux which fallback routine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@ and simply didn't have the time to go back and retroactively create one.
 - Fixed verbose logging handler to be __unique__ for every `channel`
 - Fixed docstrings in `Command` modules
 - Changed docker base image to `python3.9-alpine` to fix python version issues.
-- Added logic for calling correct paramiko method when reloading an encrypted SSH privat ekey ([#185](https://github.com/calebstewart/issues/185)).
-- Forced `Stream.RAW` for all GTFOBins interaction ([#195](https://github.com/calebstewart/issues/195)).
+- Added logic for calling correct paramiko method when reloading an encrypted SSH privat ekey ([#185](https://github.com/calebstewart/pwncat/issues/185)).
+- Forced `Stream.RAW` for all GTFOBins interaction ([#195](https://github.com/calebstewart/pwncat/issues/195)).
+- Added custom `which` implementation for linux when `which` is not available ([#193](https://github.com/calebstewart/pwncat/issues/193)).
 ### Added
 - Added alternatives to `bash` to be used during _shell upgrade_ for a _better shell_
 - Added a warning message when a `KeyboardInterrupt` is caught


### PR DESCRIPTION
## Description of Changes

Added a custom `_do_custom_which` method to the `Linux` platform. During initialization, if a local implementation of `which` is not found, pwncat will default to using this custom which implementation, which looks roughly like:

```
/bin/bash -c 'IFS='"':'"'; for path in $PATH; do if [ -f "$path/$binary_name" ]; then echo "$path/$binary_name"; fi; done; IFS='"' '"
```

Fixes #193.

## Major Changes Implemented:
- Added Linux which fallback routine
- 
- 

## Pre-Merge Tasks
- [x] Formatted all modified files w/ `python-black`
- [x] Sorted imports for modified files w/ `isort`
- [x] Ran `flake8` on repo, and fixed any new problems w/ modified files
- [x] Ran `pytest` test cases
- [x] Added brief summary of updates to CHANGELOG (under `[Unreleased]`)

<!--
If you are submitting a pull request for a new module, the following
information is also helpful:

## Platform and Environment Restrictions
(e.g. "Windows targets without HOTFIX XXXXXX")

## Full Qualified Module Name
(e.g. "linux.enumerate.system.network")

## Artifacts Generated
(e.g. "creates file at /etc/something.ini tracked w/ a tamper")

## Tested Targets
(e.g. "Tested on Windows 10 1604")
-->
