### PR TITLE
[FIX #201] Correctly handle `--listen` argument and update documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and simply didn't have the time to go back and retroactively create one.
 - Added logic for calling correct paramiko method when reloading an encrypted SSH privat ekey ([#185](https://github.com/calebstewart/pwncat/issues/185)).
 - Forced `Stream.RAW` for all GTFOBins interaction ([#195](https://github.com/calebstewart/pwncat/issues/195)).
 - Added custom `which` implementation for linux when `which` is not available ([#193](https://github.com/calebstewart/pwncat/issues/193)).
+- Correctly handle `--listen` argument ([#201](https://github.com/calebstewart/pwncat/issues/201))
 ### Added
 - Added alternatives to `bash` to be used during _shell upgrade_ for a _better shell_
 - Added a warning message when a `KeyboardInterrupt` is caught

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -86,7 +86,7 @@ victim machine. This mode is accessed via the ``bind`` protocol.
     :caption: Catching a reverse shell
 
     # netcat syntax
-    pwncat -l 4444
+    pwncat -lp 4444
     # Full connection string
     pwncat bind://0.0.0.0:4444
     # Assumed protocol

--- a/pwncat/__main__.py
+++ b/pwncat/__main__.py
@@ -187,6 +187,8 @@ def main():
                     "[red]error[/red]: --listen is not compatible with an explicit connection string"
                 )
                 return
+            elif args.listen:
+                protocol = "bind"
 
             if (
                 sum(

--- a/pwncat/commands/connect.py
+++ b/pwncat/commands/connect.py
@@ -151,6 +151,8 @@ class Command(CommandDefinition):
                 "[red]error[/red]: --listen is not compatible with an explicit connection string"
             )
             return
+        elif args.listen:
+            protocol = "bind"
 
         if (
             sum(


### PR DESCRIPTION
## Description of Changes

The `--listen` argument was basically ignored. This happened to work as expected because we used the `--port` argument along with it normally. However, if no `--port` argument was provided, the protocol was not guessed correctly. Using the `--listen` argument is now equivalent to using the explicit `bind://` protocol when connecting.

Also, I corrected the documentation to reflect the correct options for starting a `pwncat` listener.

Fixes #201.

## Major Changes Implemented:
- Correctly set the protocol when using the `--listen` argument.
- Corrected documentation for pwncat listener.

## Pre-Merge Tasks
- [x] Formatted all modified files w/ `python-black`
- [x] Sorted imports for modified files w/ `isort`
- [x] Ran `flake8` on repo, and fixed any new problems w/ modified files
- [x] Ran `pytest` test cases
- [x] Added brief summary of updates to CHANGELOG (under `[Unreleased]`)

**For issues with pre-merge tasks, see CONTRIBUTING.md**

<!--
If you are submitting a pull request for a new module, the following
information is also helpful:

## Platform and Environment Restrictions
(e.g. "Windows targets without HOTFIX XXXXXX")

## Full Qualified Module Name
(e.g. "linux.enumerate.system.network")

## Artifacts Generated
(e.g. "creates file at /etc/something.ini tracked w/ a tamper")

## Tested Targets
(e.g. "Tested on Windows 10 1604")
-->
