### PR TITLE
Fix EUID handling in Popen and Shell Detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,14 @@ and simply didn't have the time to go back and retroactively create one.
 - Forced `Stream.RAW` for all GTFOBins interaction ([#195](https://github.com/calebstewart/pwncat/issues/195)).
 - Added custom `which` implementation for linux when `which` is not available ([#193](https://github.com/calebstewart/pwncat/issues/193)).
 - Correctly handle `--listen` argument ([#201](https://github.com/calebstewart/pwncat/issues/201))
+- Added handler for `OSError` when attempting to detect the running shell ([#179](https://github.com/calebstewart/pwncat/issues/179))
 ### Added
 - Added alternatives to `bash` to be used during _shell upgrade_ for a _better shell_
 - Added a warning message when a `KeyboardInterrupt` is caught
 - Added `--verbose/-V` for argument parser
 - Added `OSError` for `bind` protocol to show appropriate error messages
 ### Changed
+- Removed handling of `shell` argument to `Popen` to prevent `euid` problems ([#179](https://github.com/calebstewart/pwncat/issues/179))
 - Changed some 'red' warning message color to 'yellow'
 - Leak private keys for all users w/ file-read ability as UID=0 ([#181](https://github.com/calebstewart/pwncat/issues/181))
 - Raise `PermissionError` when underlying processes terminate unsuccessfully for `LinuxReader` and `LinuxWriter`

--- a/pwncat/platform/linux.py
+++ b/pwncat/platform/linux.py
@@ -1672,6 +1672,9 @@ class Linux(Platform):
                 self.shell = self.getenv("SHELL")
                 if self.shell is None or self.shell == "":
                     self.shell = "/bin/sh"
+
+            # Refresh the currently tracked user and group IDs
+            self.refresh_uid()
         else:
 
             # Going interactive requires a pty

--- a/pwncat/platform/linux.py
+++ b/pwncat/platform/linux.py
@@ -1127,9 +1127,12 @@ class Linux(Platform):
                 f"attempting to run {repr(command)} during execution of {self.command_running.args}!"
             )
 
-        if shell:
-            # Ensure this works normally
-            command = shlex.join(["/bin/sh", "-c", command])
+        # This breaks `euid` situations. Not all shells support -p, so I think just not
+        # using this is a better option. I'm leaving it here just in case removing it
+        # causes problems in the future. Tests seem positive so far.
+        # if shell:
+        #     # Ensure this works normally
+        #     command = shlex.join(["/bin/sh", "-c", command])
 
         if cwd is not None:
             command = f"(cd {cwd} && {command})"
@@ -1664,9 +1667,11 @@ class Linux(Platform):
                 pid = self.getenv("$")
                 # Grab the path to the executable representing the shell
                 self.shell = self.Path("/proc", pid, "exe").readlink()
-            except (FileNotFoundError, PermissionError):
+            except (FileNotFoundError, PermissionError, OSError):
                 # Fall back to SHELL even though it's not really trustworthy
                 self.shell = self.getenv("SHELL")
+                if self.shell is None or self.shell == "":
+                    self.shell = "/bin/sh"
         else:
 
             # Going interactive requires a pty


### PR DESCRIPTION
## Description of Changes

As discussed in #179, the handling of `euid` processes during `Popen` with `shell=True` and during shell detection causes uncaught exceptions or dropped permissions.

In the former case, I simply removed the handling of `shell=True` from `Linux.Popen`. The way that pwncat executes processes without `/bin/sh -c` is equivalent to running with `/bin/sh -c`, so I don't believe this will cause any issues, but needs some more testing before merging.

In the latter case, I simply caught the `OSError` raised by `Path.readlink()` during shell detection. In this case, we fall back to using the `SHELL` environment variable which is unreliable at best. This means that normally, if you are in a `euid` context, you will lose fancy shell highlighting, but this is mainly cosmetic and doing this ensures pwncat doesn't crash and drop your session.

I don't believe this fully fixes the aforementioned issue. To fully fix that problem, I think implementing a module for correcting `euid` situations after escalation is ideal. In reality, you don't ever want to be in a `euid` situation because permissions are... weird... and many utilities will drop your permissions unexpectedly. We can *normally* rectify this, so I don't want to close that issue until a module that resolves this is implemented.

**Please note any `noqa:` comments needed to appease flake8.**

## Major Changes Implemented:
- Removed handling of `shell` argument to `Linux.Popen`
- Added `OSError` handler in shell detection routine.

## Pre-Merge Tasks
- [x] Formatted all modified files w/ `python-black`
- [x] Sorted imports for modified files w/ `isort`
- [x] Ran `flake8` on repo, and fixed any new problems w/ modified files
- [x] Ran `pytest` test cases
- [x] Added brief summary of updates to CHANGELOG (under `[Unreleased]`)

**For issues with pre-merge tasks, see CONTRIBUTING.md**

<!--
If you are submitting a pull request for a new module, the following
information is also helpful:

## Platform and Environment Restrictions
(e.g. "Windows targets without HOTFIX XXXXXX")

## Full Qualified Module Name
(e.g. "linux.enumerate.system.network")

## Artifacts Generated
(e.g. "creates file at /etc/something.ini tracked w/ a tamper")

## Tested Targets
(e.g. "Tested on Windows 10 1604")
-->
