### PR TITLE
Add installation instructions for BlackArch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and simply didn't have the time to go back and retroactively create one.
 - Added `--verbose/-V` for argument parser
 - Added `OSError` for `bind` protocol to show appropriate error messages
 - Contributing guidelines for GitHub maintainers
+- Installation instructions for BlackArch
 ### Changed
 - Changed some 'red' warning message color to 'yellow'
 - Leak private keys for all users w/ file-read ability as UID=0 ([#181](https://github.com/calebstewart/pwncat/issues/181))

--- a/README.md
+++ b/README.md
@@ -131,6 +131,16 @@ The setup script will install three binaries. They are all identical, but
 provide convenience aliases for pwncat. The three binaries are: `pwncat`,
 `pc` and `pcat`.
 
+## BlackArch Packaging
+
+[![Packaging status](https://repology.org/badge/vertical-allrepos/pwncat-caleb.svg)](https://repology.org/project/pwncat-caleb/versions)
+
+Installation on BlackArch is as simple as:
+
+``` shell
+pacman -Syu pwncat-caleb
+```
+
 ### Connecting to a Victim
 
 The command line parameters for pwncat attempt to be flexible and accept 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -52,6 +52,16 @@ After installation, you can use pwncat via the installed script:
       --list                List installed implants with remote connection
                             capability
 
+BlackArch Package
+-----------------
+
+pwncat is packaged for BlackArch and in the standard repositories. Installation on
+BlackArch is as simple as:
+
+.. code-block:: bash
+
+    $ pacman -Syu pwncat-caleb
+
 Windows Plugin Binaries
 -----------------------
 


### PR DESCRIPTION
## Description of Changes

Added packaging status and installation instructions for BlackArch linux.

Fixes #178.

**Please note any `noqa:` comments needed to appease flake8.**

## Major Changes Implemented:
- Added packaging status to `README.md`
- Added installation instructions to documentation.

## Pre-Merge Tasks
- [x] Formatted all modified files w/ `python-black`
- [x] Sorted imports for modified files w/ `isort`
- [x] Ran `flake8` on repo, and fixed any new problems w/ modified files
- [x] Ran `pytest` test cases
- [x] Added brief summary of updates to CHANGELOG (under `[Unreleased]`)

<!--
If you are submitting a pull request for a new module, the following
information is also helpful:

## Platform and Environment Restrictions
(e.g. "Windows targets without HOTFIX XXXXXX")

## Full Qualified Module Name
(e.g. "linux.enumerate.system.network")

## Artifacts Generated
(e.g. "creates file at /etc/something.ini tracked w/ a tamper")

## Tested Targets
(e.g. "Tested on Windows 10 1604")
-->
