### PR TITLE
Issues 208 (stat output verification) and 210 (shell detection) fixes 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and simply didn't have the time to go back and retroactively create one.
 - Forced `Stream.RAW` for all GTFOBins interaction ([#195](https://github.com/calebstewart/pwncat/issues/195)).
 - Added custom `which` implementation for linux when `which` is not available ([#193](https://github.com/calebstewart/pwncat/issues/193)).
 - Correctly handle `--listen` argument ([#201](https://github.com/calebstewart/pwncat/issues/201))
+- Added additional check for stat time of file birth field (#208)
+- Removed shell compare with ["nologin", "false", "sync", "git-shell"] (#210)
+- Added shell compare with not in ["bash", "zsh", "ksh", "fish"] (#210)
 ### Added
 - Added alternatives to `bash` to be used during _shell upgrade_ for a _better shell_
 - Added a warning message when a `KeyboardInterrupt` is caught

--- a/pwncat/platform/linux.py
+++ b/pwncat/platform/linux.py
@@ -615,20 +615,15 @@ class Linux(Platform):
 
         if self.shell == "" or self.shell is None:
             self.shell = "/bin/sh"
-
-        # This doesn't make sense, but happened for some people (see issue #116)
-        if os.path.basename(self.shell) in ["nologin", "false", "sync", "git-shell"]:
-            self.shell = "/bin/sh"
-            self.channel.sendline(b" export SHELL=/bin/sh")
-
+                      
         if self._do_which("which") is None:
             self._do_which = self._do_custom_which
 
-        if os.path.basename(self.shell) in ["sh", "dash"]:
+        better_shells = ["bash", "zsh", "ksh", "fish"]
+        if os.path.basename(self.shell) not in better_shells:
             # Try to find a better shell
             # a custom `pwncat shell prompt` may not be available for all shells
             # see `self.PROMPTS`
-            better_shells = ["bash", "zsh", "ksh", "fish"]
 
             for better_shell in better_shells:
                 shell = self._do_which(better_shell)

--- a/pwncat/platform/linux.py
+++ b/pwncat/platform/linux.py
@@ -1735,8 +1735,12 @@ class Linux(Platform):
         #  14 total size in bytes
 
         for i in range(len(fields)):
-            if not fields[i].isdigit():
+            if fields[i] == "?":
                 fields[i] = "0"
+
+        # Fix stat output issues in some enviroments
+        if fields[1] == "W":
+            fields[1] = "0"
 
         stat = os.stat_result(
             tuple(

--- a/pwncat/platform/linux.py
+++ b/pwncat/platform/linux.py
@@ -1740,7 +1740,7 @@ class Linux(Platform):
         #  14 total size in bytes
 
         for i in range(len(fields)):
-            if fields[i] == "?":
+            if not fields[i].isdigit():
                 fields[i] = "0"
 
         stat = os.stat_result(

--- a/pwncat/platform/linux.py
+++ b/pwncat/platform/linux.py
@@ -615,7 +615,7 @@ class Linux(Platform):
 
         if self.shell == "" or self.shell is None:
             self.shell = "/bin/sh"
-                      
+
         if self._do_which("which") is None:
             self._do_which = self._do_custom_which
 


### PR DESCRIPTION
## Description of Changes

Fixes #208 and #210 Issues.


## Major Changes Implemented:
- Added additional check for stat time of file birth field 
- Removed shell compare with ["nologin", "false", "sync", "git-shell"]
-  Added shell compare with `not in ["bash", "zsh", "ksh", "fish"]`

## Pre-Merge Tasks
- [x] Formatted all modified files w/ `python-black`
- [x] Sorted imports for modified files w/ `isort`
- [x] Ran `flake8` on repo, and fixed any new problems w/ modified files
- [x] Ran `pytest` test cases
- [ ] Added brief summary of updates to CHANGELOG (under `[Unreleased]`
