### PR TITLE
Added lpwd and lcd commands for local cwd changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and simply didn't have the time to go back and retroactively create one.
 - Added `OSError` for `bind` protocol to show appropriate error messages
 - Contributing guidelines for GitHub maintainers
 - Installation instructions for BlackArch
+- Added `lpwd` and `lcd` commands to interact with the local working directory ([#218](https://github.com/calebstewart/pwncat/issues/218))
 ### Changed
 - Removed handling of `shell` argument to `Popen` to prevent `euid` problems ([#179](https://github.com/calebstewart/pwncat/issues/179))
 - Changed some 'red' warning message color to 'yellow'

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,4 +10,6 @@ zodburi==2.4.0
 jinja2
 paramiko==2.7.2
 sphinx-toolbox==2.11.2
+apeye<1.0.0
 enum-tools==0.6.4
+sphinx_rtd_theme==1.0.0

--- a/docs/source/commands/index.rst
+++ b/docs/source/commands/index.rst
@@ -12,7 +12,9 @@ Command index
     connect.rst
     download.rst
     escalate.rst
+    lcd.rst
     load.rst
+    lpwd.rst
     run.rst
     info.rst
     search.rst

--- a/docs/source/commands/lcd.rst
+++ b/docs/source/commands/lcd.rst
@@ -1,0 +1,14 @@
+lcd
+===
+
+The ``lcwd`` command allows you to change the *local* working directory of the running
+pwncat instance. This effects any command which interacts with the local filesystem (
+e.g. ``upload`` and ``download``).
+
+.. code-block:: bash
+
+   # Example from @DanaEpp :P
+   lcd ~/engagements/client_some_gawd_aweful_guid/host_abc/loot
+   # Now, the following downloads will end up in the above directory
+   download /path/to/some/loot
+   download /paht/to/some/other/loot

--- a/docs/source/commands/lpwd.rst
+++ b/docs/source/commands/lpwd.rst
@@ -1,0 +1,10 @@
+lpwd
+====
+
+The ``lpwd`` directory will print the current *local* working directory. This is the directory
+which commands like ``upload`` and ``download`` will interpret as ``.``.
+
+.. code-block:: bash
+
+   # Print the local working directory
+   lpwd

--- a/pwncat/commands/lcd.py
+++ b/pwncat/commands/lcd.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+import os
+import pathlib
+
+import pwncat
+from pwncat.commands import Complete, Parameter, CommandDefinition
+
+
+class Command(CommandDefinition):
+    """Change the local current working directory"""
+
+    PROG = "lcd"
+    ARGS = {
+        "path": Parameter(Complete.LOCAL_FILE),
+    }
+
+    def run(self, manager: "pwncat.manager.Manager", args):
+
+        # Expand `~`
+        path = pathlib.Path(args.path).expanduser()
+
+        # Ensure the directory exists
+        if not path.is_dir():
+            self.parser.error(f"{path}: not a directory")
+
+        # Change to that directory
+        os.chdir(str(path))

--- a/pwncat/commands/lpwd.py
+++ b/pwncat/commands/lpwd.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+import pwncat
+from pwncat.util import console
+from pwncat.commands import CommandDefinition
+
+
+class Command(CommandDefinition):
+    """Print the local current working directory"""
+
+    PROG = "lpwd"
+    ARGS = {}
+
+    def run(self, manager: "pwncat.manager.Manager", args):
+
+        console.print(Path.cwd())


### PR DESCRIPTION
## Description of Changes
Added `lpwd` command for printing the current local working directory, and the `lcd` command for changing the current local working directory.

Fixes #218.

**Please note any `noqa:` comments needed to appease flake8.**

## Major Changes Implemented:
- Added `lcd` and `lpwd` commands
- Added relevant documentation.

## Pre-Merge Tasks
- [x] Formatted all modified files w/ `python-black`
- [x] Sorted imports for modified files w/ `isort`
- [x] Ran `flake8` on repo, and fixed any new problems w/ modified files
- [x] Ran `pytest` test cases
- [x] Added brief summary of updates to CHANGELOG (under `[Unreleased]`)

**For issues with pre-merge tasks, see CONTRIBUTING.md**

<!--
If you are submitting a pull request for a new module, the following
information is also helpful:

## Platform and Environment Restrictions
(e.g. "Windows targets without HOTFIX XXXXXX")

## Full Qualified Module Name
(e.g. "linux.enumerate.system.network")

## Artifacts Generated
(e.g. "creates file at /etc/something.ini tracked w/ a tamper")

## Tested Targets
(e.g. "Tested on Windows 10 1604")
-->
