### PR TITLE
pwncat: commands network interface

### DIFF
--- a/pwncat/commands/network_interface.py
+++ b/pwncat/commands/network_interface.py
@@ -1,0 +1,15 @@
+import netifaces
+
+netifaces.gateways()
+
+interfaces = netifaces.interfaces()
+
+for interface in interfaces:
+	print(interface)
+
+print(netifaces.ifaddresses(str(interfaces[0])))
+
+addrs = netifaces.ifaddresses(str(interfaces[0]))
+print(addrs[netifaces.AF_INET])
+print(addrs[netifaces.AF_LINK])
+


### PR DESCRIPTION
hey @calebstewart I have added functions to get the network interface of the target machine after shell popup.

by: @krishpranav