### PR TITLE
Fixed ssl parsing in entrypoint/connect command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and simply didn't have the time to go back and retroactively create one.
 
 ## [Unreleased]
 
+### Changed
+- Fixed parsing of `--ssl` argument ([#231](https://github.com/calebstewart/pwncat/issues/231)).
+
 ## [0.5.2] - 2021-12-31
 Bug fixes for argument parsing and improved SSH key support thanks to
 `paramiko-ng`. Moved to a prettier theme for ReadTheDocs documentation.

--- a/pwncat/__main__.py
+++ b/pwncat/__main__.py
@@ -233,16 +233,20 @@ def main():
             if query_args["certfile"] is not None or query_args["keyfile"] is not None:
                 query_args["ssl"] = True
 
-            if query_args["protocol"] not in [
-                None,
-                "bind",
-                "connect",
-            ] and query_args.get("ssl"):
+            if (
+                query_args["protocol"]
+                not in [
+                    None,
+                    "bind",
+                    "connect",
+                ]
+                and query_args.get("ssl")
+            ):
                 console.log(
                     f"[red]error[/red]: --ssl is incompatible with an [yellow]{query_args['protocol']}[/yellow] protocol"
                 )
                 return
-            elif query_args["protocol"] is not None:
+            elif query_args["protocol"] is not None and query_args.get("ssl"):
                 query_args["protocol"] = "ssl-" + query_args["protocol"]
 
             if (

--- a/pwncat/commands/connect.py
+++ b/pwncat/commands/connect.py
@@ -202,7 +202,7 @@ class Command(CommandDefinition):
                 f"[red]error[/red]: --ssl is incompatible with an [yellow]{query_args['protocol']}[/yellow] protocol"
             )
             return
-        elif query_args["protocol"] is not None:
+        elif query_args["protocol"] is not None and query_args.get("ssl"):
             query_args["protocol"] = "ssl-" + query_args["protocol"]
 
         if (


### PR DESCRIPTION
## Description of Changes

This PR fixes #231 which was a bug caused by the previous release that I didn't catch. :frowning_face: 

## Major Changes Implemented:
- Fixed parsing of `--ssl` argument ([#231](https://github.com/calebstewart/pwncat/issues/231)).

## Pre-Merge Tasks
- [x] Formatted all modified files w/ `python-black`
- [x] Sorted imports for modified files w/ `isort`
- [x] Ran `flake8` on repo, and fixed any new problems w/ modified files
- [x] Ran `pytest` test cases
- [x] Added brief summary of updates to CHANGELOG (under `[Unreleased]`)

**For issues with pre-merge tasks, see CONTRIBUTING.md**

<!--
If you are submitting a pull request for a new module, the following
information is also helpful:

## Platform and Environment Restrictions
(e.g. "Windows targets without HOTFIX XXXXXX")

## Full Qualified Module Name
(e.g. "linux.enumerate.system.network")

## Artifacts Generated
(e.g. "creates file at /etc/something.ini tracked w/ a tamper")

## Tested Targets
(e.g. "Tested on Windows 10 1604")
-->
