### PR TITLE
Fixed load command path argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The Changelog starts with v0.4.1, because we did not keep one before that,
 and simply didn't have the time to go back and retroactively create one.
 
+## [Unreleased]
+
+### Changed
+- Fixed `Manger.load_modules` call in `pwncat/commands/load.py`.
+
 ## [0.5.3] - 2022-01-09
 Fix for argument parsing bug introduced in `0.5.2` which caused bind/connect
 protocols to be automatically interpreted as SSL even when `--ssl` was not

--- a/pwncat/commands/load.py
+++ b/pwncat/commands/load.py
@@ -28,4 +28,4 @@ class Command(CommandDefinition):
 
     def run(self, manager: "pwncat.manager.Manager", args):
 
-        manager.load_modules(args.path)
+        manager.load_modules(*args.path)


### PR DESCRIPTION
## Description of Changes

The `load` command incorrectly passed the path argument to `Manager.load_modules` as a list instead of expanding to the positional arguments. This fix simply adds the asterisk to expand the list to positional arguments. 

**Please note any `noqa:` comments needed to appease flake8.**

## Major Changes Implemented:
- Fixed `Manger.load_modules` call in `pwncat/commands/load.py`.

## Pre-Merge Tasks
- [x] Formatted all modified files w/ `python-black`
- [x] Sorted imports for modified files w/ `isort`
- [x] Ran `flake8` on repo, and fixed any new problems w/ modified files
- [x] Ran `pytest` test cases
- [x] Added brief summary of updates to CHANGELOG (under `[Unreleased]`)

**For issues with pre-merge tasks, see CONTRIBUTING.md**

<!--
If you are submitting a pull request for a new module, the following
information is also helpful:

## Platform and Environment Restrictions
(e.g. "Windows targets without HOTFIX XXXXXX")

## Full Qualified Module Name
(e.g. "linux.enumerate.system.network")

## Artifacts Generated
(e.g. "creates file at /etc/something.ini tracked w/ a tamper")

## Tested Targets
(e.g. "Tested on Windows 10 1604")
-->
