### PR TITLE
Moved XDG config loading to entrypoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The Changelog starts with v0.4.1, because we did not keep one before that,
 and simply didn't have the time to go back and retroactively create one.
 
+## [Unreleased]
+
+### Changed
+- Removed default configuration loading from `Manager` class.
+- Added XDG-compliant configuration and module loading to the main entrypoint.
+
 ## [0.5.4] - 2022-01-27
 Bug fix for the `load` command.
 

--- a/pwncat/manager.py
+++ b/pwncat/manager.py
@@ -37,8 +37,7 @@ import threading
 import contextlib
 from io import TextIOWrapper
 from enum import Enum, auto
-from typing import Dict, List, Tuple, Union, TextIO, Callable, Optional, Generator
-from pathlib import Path
+from typing import Dict, List, Tuple, Union, Callable, Optional, Generator
 
 import ZODB
 import zodburi

--- a/pwncat/manager.py
+++ b/pwncat/manager.py
@@ -37,7 +37,8 @@ import threading
 import contextlib
 from io import TextIOWrapper
 from enum import Enum, auto
-from typing import Dict, List, Tuple, Union, Callable, Optional, Generator
+from typing import Dict, List, Tuple, Union, TextIO, Callable, Optional, Generator
+from pathlib import Path
 
 import ZODB
 import zodburi
@@ -821,36 +822,6 @@ class Manager:
         # Load standard modules
         self.load_modules(*pwncat.modules.__path__)
 
-        # Get our data directory
-        data_home = os.environ.get("XDG_DATA_HOME", "~/.local/share")
-        if not data_home:
-            data_home = "~/.local/share"
-
-        # Expand the user path
-        data_home = os.path.expanduser(os.path.join(data_home, "pwncat"))
-
-        # Find modules directory
-        modules_dir = os.path.join(data_home, "modules")
-
-        # Load local modules if they exist
-        if os.path.isdir(modules_dir):
-            self.load_modules(modules_dir)
-
-        # Load global configuration script, if available
-        try:
-            with open("/etc/pwncat/pwncatrc") as filp:
-                self.parser.eval(filp.read(), "/etc/pwncat/pwncatrc")
-        except (FileNotFoundError, PermissionError):
-            pass
-
-        # Load user configuration script
-        user_rc = os.path.join(data_home, "pwncatrc")
-        try:
-            with open(user_rc) as filp:
-                self.parser.eval(filp.read(), user_rc)
-        except (FileNotFoundError, PermissionError):
-            pass
-
         # Load local configuration script
         if isinstance(config, str):
             with open(config) as filp:
@@ -858,14 +829,6 @@ class Manager:
         elif config is not None:
             self.parser.eval(config.read(), getattr(config, "name", "fileobj"))
             config.close()
-        else:
-            try:
-                # If no config is specified, attempt to load `./pwncatrc`
-                # but don't fail if it doesn't exist.
-                with open("./pwncatrc") as filp:
-                    self.parser.eval(filp.read(), "./pwncatrc")
-            except (FileNotFoundError, PermissionError):
-                pass
 
         if self.db is None:
             self.open_database()

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -21,31 +21,11 @@ set -g backdoor_user "config_test"
 
 def test_user_config(tmp_path):
 
-    import os
+    # Create our user configuration
+    with (tmp_path / "pwncatrc").open("w") as filp:
+        filp.writelines(["""set -g backdoor_user "config_test"\n"""])
 
-    # Ensure we don't muck up the environment for this process
-    old_home = os.environ.get("XDG_DATA_HOME", None)
-
-    try:
-        # Set the data home to our temp path
-        os.environ["XDG_DATA_HOME"] = str(tmp_path)
-
-        # Create the pwncat directory
-        (tmp_path / "pwncat").mkdir(exist_ok=True, parents=True)
-
-        # Create our user configuration
-        with (tmp_path / "pwncat" / "pwncatrc").open("w") as filp:
-            filp.writelines(["""set -g backdoor_user "config_test"\n"""])
-
-        os.chdir(tmp_path)
-
-        # Create a manager object with default config to load our
-        # user configuration.
-        with pwncat.manager.Manager(config=None) as manager:
-            assert manager.config["backdoor_user"] == "config_test"
-    finally:
-        # Restore the environment
-        if old_home is not None:
-            os.environ["XDG_DATA_HOME"] = old_home
-        else:
-            del os.environ["XDG_DATA_HOME"]
+    # Create a manager object with default config to load our
+    # user configuration.
+    with pwncat.manager.Manager(config=str(tmp_path / "pwncatrc")) as manager:
+        assert manager.config["backdoor_user"] == "config_test"


### PR DESCRIPTION
## Description of Changes

Removed loading configuration from XDG directories out of the Manager
constructor and into the main entrypoint, and modified logic to comply
with the XDG Base Directories specification. This should now obey
XDG_CONFIG_HOME, XDG_CONFIG_DIRS, XDG_DATA_HOME and
XDG_DATA_DIRS with correct precedence. Modules from any data
directory will also be loaded (e.g. `/etc/pwncat/modules` or
`~/.local/share/pwncat/modules`).

If no configuration is passed to the `Manager` constructor, it will no
longer load any configuration by default (the built-in modules will still be
loaded, though).

I also had to update the unit test for custom configurations, since the
`Manager` class no longer loads from XDG directories.

Fixes #239 

**Please note any `noqa:` comments needed to appease flake8.**

## Major Changes Implemented:
- Removed default configuration loading from `Manager` class.
- Added XDG-compliant configuration and module loading to the main entrypoint.

## Pre-Merge Tasks
- [x] Formatted all modified files w/ `python-black`
- [x] Sorted imports for modified files w/ `isort`
- [x] Ran `flake8` on repo, and fixed any new problems w/ modified files
- [x] Ran `pytest` test cases
- [x] Added brief summary of updates to CHANGELOG (under `[Unreleased]`)

**For issues with pre-merge tasks, see CONTRIBUTING.md**

<!--
If you are submitting a pull request for a new module, the following
information is also helpful:

## Platform and Environment Restrictions
(e.g. "Windows targets without HOTFIX XXXXXX")

## Full Qualified Module Name
(e.g. "linux.enumerate.system.network")

## Artifacts Generated
(e.g. "creates file at /etc/something.ini tracked w/ a tamper")

## Tested Targets
(e.g. "Tested on Windows 10 1604")
-->
