### PR TITLE
Check for correct paramiko flavor

### DIFF
--- a/pwncat/__main__.py
+++ b/pwncat/__main__.py
@@ -177,11 +177,19 @@ def main():
             query_args["host"] = None
             query_args["port"] = None
             query_args["platform"] = args.platform
-            query_args["identity"] = args.identity
             query_args["certfile"] = args.ssl_cert
             query_args["keyfile"] = args.ssl_key
             query_args["ssl"] = args.ssl
             querystring = None
+            
+            if args.identity is not None:
+                import paramiko
+                if not 'load_private_key' in paramiko.__all__:
+                    console.log(
+                        "[red]error[/red]: Wrong version of paramiko found.  Make sure that only [blue]paramiko-ng[/blue] but not [blue]paramiko[/blue] is installed."
+                    )
+                    return
+            query_args["identity"] = args.identity
 
             if args.connection_string:
                 m = connect.Command.CONNECTION_PATTERN.match(args.connection_string)


### PR DESCRIPTION
## Description of Changes

If `paramiko` is installed besides `paramiko-ng` and an identity file is used, `pwncat` will fail with an AttributeError.

**Please note any `noqa:` comments needed to appease flake8.**

## Major Changes Implemented:
- Fail early if `paramiko` instead of `paramiko-ng` is found.

## Pre-Merge Tasks
- [ ] Formatted all modified files w/ `python-black`
- [ ] Sorted imports for modified files w/ `isort`
- [ ] Ran `flake8` on repo, and fixed any new problems w/ modified files
- [ ] Ran `pytest` test cases
- [ ] Added brief summary of updates to CHANGELOG (under `[Unreleased]`)

**For issues with pre-merge tasks, see CONTRIBUTING.md**

<!--
If you are submitting a pull request for a new module, the following
information is also helpful:

## Platform and Environment Restrictions
(e.g. "Windows targets without HOTFIX XXXXXX")

## Full Qualified Module Name
(e.g. "linux.enumerate.system.network")

## Artifacts Generated
(e.g. "creates file at /etc/something.ini tracked w/ a tamper")

## Tested Targets
(e.g. "Tested on Windows 10 1604")
-->
