### PR TITLE
Verify .ssh directory permissions before adding authkeys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and simply didn't have the time to go back and retroactively create one.
 - Fixed `set` command use with incorrect keys (e.g. `set invalid value`)
 
 ### Added
+- Permission checks on the .ssh directory before adding authkeys, tamper module for reverts.
 - Added missed `PlatformError` for `upload` command (e.g. "no gtfobins writers available")
 
 ## [0.5.4] - 2022-01-27

--- a/pwncat/facts/tamper.py
+++ b/pwncat/facts/tamper.py
@@ -217,6 +217,7 @@ class CreatedDirectory(Tamper):
             session, f"created directory at [cyan]{self.path}[cyan]"
         )
 
+
 class ModifiedPermissions(Tamper):
     """Tracks permission changes to files and directories on the target.
     The previous permissions will be set on a revert.
@@ -252,7 +253,7 @@ class ModifiedPermissions(Tamper):
     def revert(self, session: "pwncat.manager.Session"):
 
         try:
-            session.platform.Path(self.path).chmod(mode)
+            session.platform.Path(self.path).chmod(self.mode)
         except FileNotFoundError:
             raise ModuleFailed("file not found error")
 

--- a/pwncat/facts/tamper.py
+++ b/pwncat/facts/tamper.py
@@ -216,3 +216,49 @@ class CreatedDirectory(Tamper):
         return self._annotate_title(
             session, f"created directory at [cyan]{self.path}[cyan]"
         )
+
+class ModifiedPermissions(Tamper):
+    """Tracks permission changes to files and directories on the target.
+    The previous permissions will be set on a revert.
+
+    :param source: generating module or routine
+    :type source: str
+    :param uid: UID needed to revert
+    :type uid: Union[int, str]
+    :param path: path to replaced file
+    :type path: str
+    :param mode: original permissions on the file or directory
+    :type mode: int
+    :param timestamp: the datetime that this change occurred
+    :type timestamp: Optional[datetime.datetime]
+    """
+
+    def __init__(
+        self,
+        source: str,
+        uid: Union[int, str],
+        path: str,
+        mode: int,
+        timestamp: Optional[datetime.datetime] = None,
+    ):
+        super().__init__(source, uid, timestamp=timestamp)
+
+        self.path = path
+
+    @property
+    def revertable(self):
+        return True
+
+    def revert(self, session: "pwncat.manager.Session"):
+
+        try:
+            session.platform.Path(self.path).chmod(mode)
+        except FileNotFoundError:
+            raise ModuleFailed("file not found error")
+
+        self.reverted = True
+
+    def title(self, session: "pwncat.manager.Session"):
+        return self._annotate_title(
+            session, f"modified permissions on [cyan]{self.path}[cyan]"
+        )

--- a/pwncat/modules/linux/implant/authorized_key.py
+++ b/pwncat/modules/linux/implant/authorized_key.py
@@ -3,8 +3,9 @@ import os
 import pathlib
 
 import pwncat
-from pwncat.facts import PrivateKey, CreatedFile, CreatedDirectory, ModifiedPermissions
+from pwncat.facts import PrivateKey
 from pwncat.modules import Status, Argument, ModuleFailed
+from pwncat.facts.tamper import CreatedFile, CreatedDirectory, ModifiedPermissions
 from pwncat.platform.linux import Linux
 from pwncat.modules.implant import ImplantModule
 
@@ -133,14 +134,18 @@ class Module(ImplantModule):
             sshdir.mkdir(parents=True, exist_ok=True)
             # Register the fact that we created this directory
             # so that we can later revert it
-            session.register_fact(CreatedDirectory(self.source, implant.uid, str(sshdir)))
+            session.register_fact(
+                CreatedDirectory(self.source, implant.uid, str(sshdir))
+            )
 
         # Modify the permissions if it was incorrectly set
         permissions = sshdir.stat().st_mode
         if permissions != 0o40700:
             yield Status("fixing .ssh directory permissions")
             sshdir.chmod(0o40700)
-            session.register_fact(ModifiedPermissions(self.source, implant.uid, str(sshdir), permissions))
+            session.register_fact(
+                ModifiedPermissions(self.source, implant.uid, str(sshdir), permissions)
+            )
 
         authkeys_path = sshdir / "authorized_keys"
         creating_authkeys = False
@@ -166,7 +171,9 @@ class Module(ImplantModule):
             with authkeys_path.open("w") as filp:
                 filp.writelines(authkeys)
                 if creating_authkeys:
-                    session.register_fact(CreatedFile(self.source, implant.uid, str(authkeys_path)))
+                    session.register_fact(
+                        CreatedFile(self.source, implant.uid, str(authkeys_path))
+                    )
         except (FileNotFoundError, PermissionError) as exc:
             raise ModuleFailed(str(exc)) from exc
 


### PR DESCRIPTION
## Description of Changes
Addresses #260. The Linux implant module for authorized keys now checks the permissions on the .ssh directory before adding the keys. If the .ssh directory does not exist, besides creating it, we also record that fact for later reverts. Similar reverts can be made to the authorized_keys file if created and any permission changes.


**Please note any `noqa:` comments needed to appease flake8.**

## Major Changes Implemented:
- Added tamper class `ModifiedPermissions`
- Authorized keys implant now checks the permissions on the .ssh directory
- Directory and file creation as well as permission changes by the implant can be reverted.

## Pre-Merge Tasks
- [x] Formatted all modified files w/ `python-black`
- [x] Sorted imports for modified files w/ `isort`
- [x] Ran `flake8` on repo, and fixed any new problems w/ modified files
- [x] Ran `pytest` test cases
- [x] Added brief summary of updates to CHANGELOG (under `[Unreleased]`)

**For issues with pre-merge tasks, see CONTRIBUTING.md**

<!--
If you are submitting a pull request for a new module, the following
information is also helpful:

## Platform and Environment Restrictions
(e.g. "Windows targets without HOTFIX XXXXXX")

## Full Qualified Module Name
(e.g. "linux.enumerate.system.network")

## Artifacts Generated
(e.g. "creates file at /etc/something.ini tracked w/ a tamper")

## Tested Targets
(e.g. "Tested on Windows 10 1604")
-->
