### PR TITLE
Methodically check existence and permissions before adding authkeys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and simply didn't have the time to go back and retroactively create one.
 - Fixed `set` command use with incorrect keys (e.g. `set invalid value`)
 
 ### Added
+- Permission checks on the .ssh directory before adding authkeys, tamper module for reverts.
 - Added missed `PlatformError` for `upload` command (e.g. "no gtfobins writers available")
 
 ## [0.5.4] - 2022-01-27

--- a/pwncat/facts/tamper.py
+++ b/pwncat/facts/tamper.py
@@ -245,6 +245,7 @@ class ModifiedPermissions(Tamper):
         super().__init__(source, uid, timestamp=timestamp)
 
         self.path = path
+        self.mode = mode
 
     @property
     def revertable(self):
@@ -263,4 +264,59 @@ class ModifiedPermissions(Tamper):
         print(session.find_user(uid=self.uid))
         return self._annotate_title(
             session, f"modified permissions on [cyan]{self.path}[cyan]"
+        )
+
+
+class ModifiedOwnership(Tamper):
+    """Tracks ownership changes to files and directories on the target.
+    The previous ownerships will be set on a revert.
+
+    :param source: generating module or routine
+    :type source: str
+    :param uid: UID needed to revert
+    :type uid: Union[int, str]
+    :param path: path to replaced file
+    :type path: str
+    :param o_uid: UID of the original owner
+    :type o_uid: int
+    :param o_gid: GID of the original owner
+    :type o_gid: int
+    :param timestamp: the datetime that this change occurred
+    :type timestamp: Optional[datetime.datetime]
+    """
+
+    def __init__(
+        self,
+        source: str,
+        uid: Union[int, str],
+        path: str,
+        o_uid: int,
+        o_gid: int,
+        timestamp: Optional[datetime.datetime] = None,
+    ):
+        super().__init__(source, uid, timestamp=timestamp)
+
+        self.path = path
+        self.o_uid = o_uid
+        self.o_gid = o_gid
+
+    @property
+    def revertable(self):
+        return True
+
+    def revert(self, session: "pwncat.manager.Session"):
+
+        try:
+            session.platform.chown(
+                session.platform.Path(self.path), self.o_uid, self.o_gid
+            )
+        except (FileNotFoundError, PermissionError):
+            raise ModuleFailed("file not found error")
+
+        self.reverted = True
+
+    def title(self, session: "pwncat.manager.Session"):
+        print(session.find_user(uid=self.uid))
+        return self._annotate_title(
+            session, f"modified ownership of [cyan]{self.path}[cyan]"
         )

--- a/pwncat/facts/tamper.py
+++ b/pwncat/facts/tamper.py
@@ -216,3 +216,51 @@ class CreatedDirectory(Tamper):
         return self._annotate_title(
             session, f"created directory at [cyan]{self.path}[cyan]"
         )
+
+
+class ModifiedPermissions(Tamper):
+    """Tracks permission changes to files and directories on the target.
+    The previous permissions will be set on a revert.
+
+    :param source: generating module or routine
+    :type source: str
+    :param uid: UID needed to revert
+    :type uid: Union[int, str]
+    :param path: path to replaced file
+    :type path: str
+    :param mode: original permissions on the file or directory
+    :type mode: int
+    :param timestamp: the datetime that this change occurred
+    :type timestamp: Optional[datetime.datetime]
+    """
+
+    def __init__(
+        self,
+        source: str,
+        uid: Union[int, str],
+        path: str,
+        mode: int,
+        timestamp: Optional[datetime.datetime] = None,
+    ):
+        super().__init__(source, uid, timestamp=timestamp)
+
+        self.path = path
+
+    @property
+    def revertable(self):
+        return True
+
+    def revert(self, session: "pwncat.manager.Session"):
+
+        try:
+            session.platform.Path(self.path).chmod(self.mode)
+        except FileNotFoundError:
+            raise ModuleFailed("file not found error")
+
+        self.reverted = True
+
+    def title(self, session: "pwncat.manager.Session"):
+        print(session.find_user(uid=self.uid))
+        return self._annotate_title(
+            session, f"modified permissions on [cyan]{self.path}[cyan]"
+        )

--- a/pwncat/modules/linux/implant/authorized_key.py
+++ b/pwncat/modules/linux/implant/authorized_key.py
@@ -125,7 +125,7 @@ class Module(ImplantModule):
             T.append(CreatedDirectory(self.name, user_info.id, str(sshdir)))
 
         yield Status("fixing .ssh directory permissions")
-        mode = sshdir.stat().st_mode % (1 << 9)
+        mode = sshdir.stat().st_mode & 0o777
         if mode != 0o700:
             sshdir.chmod(0o700)
             T.append(ModifiedPermissions(self.name, user_info.id, str(sshdir), mode))


### PR DESCRIPTION
## Description of Changes

Addresses https://github.com/calebstewart/pwncat/issues/260. The Linux implant module for authorized keys now checks for the existence of the .ssh directory and the key file. Any file or directory created in the process as well as permission changes will be reverted on calling remove on the implant.

The implant now keeps track of all the tampers it has committed and the remove function rolls back all the changes.

**Please note any `noqa:` comments needed to appease flake8.**

## Major Changes Implemented:
- Added tamper classes `ModifiedPermissions`, `ModifiedOwnership`
- Authkeys implant module keeps track of its tampers internally
- A call to `remove` on the implant rolls back any changes made

## Pre-Merge Tasks
- [x] Formatted all modified files w/ `python-black`
- [x] Sorted imports for modified files w/ `isort`
- [x] Ran `flake8` on repo, and fixed any new problems w/ modified files
- [x] Ran `pytest` test cases
- [x] Added brief summary of updates to CHANGELOG (under `[Unreleased]`)

#### `pytest` results
4 failed, 26 passed
```
tests/test_platform.py::test_platform_su[ubuntu] FAILED
tests/test_platform.py::test_platform_su[centos] FAILED
tests/test_platform.py::test_platform_sudo[ubuntu] FAILED 
tests/test_platform.py::test_platform_sudo[centos] FAILED
```

> Note: Running these tests on the pwncat master branch returned the same results for me.

**For issues with pre-merge tasks, see CONTRIBUTING.md**

<!--
If you are submitting a pull request for a new module, the following
information is also helpful:

## Platform and Environment Restrictions
(e.g. "Windows targets without HOTFIX XXXXXX")

## Full Qualified Module Name
(e.g. "linux.enumerate.system.network")

## Artifacts Generated
(e.g. "creates file at /etc/something.ini tracked w/ a tamper")

## Tested Targets
(e.g. "Tested on Windows 10 1604")
-->
