### PR TITLE
fix typo in the run-tests.sh

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -8,7 +8,7 @@ echo "[!] we can only test centos and ubuntu locally"
 CENTOS_CONTAINER=$(podman run --rm -d -p :22 -p :4444 -p :9999 -t calebjstewart/pwncat-testing:centos)
 echo "[+] started centos container: $CENTOS_CONTAINER"
 UBUNTU_CONTAINER=$(podman run --rm -d -p :22 -p :4444 -p :9999 -t calebjstewart/pwncat-testing:ubuntu)
-echo "[+] started centos container: $UBUNTU_CONTAINER"
+echo "[+] started ubuntu container: $UBUNTU_CONTAINER"
 
 CENTOS_BIND_PORT=$(podman inspect "$CENTOS_CONTAINER" | jq -r '.[0].HostConfig.PortBindings["4444/tcp"][0].HostPort')
 UBUNTU_BIND_PORT=$(podman inspect "$UBUNTU_CONTAINER" | jq -r '.[0].HostConfig.PortBindings["4444/tcp"][0].HostPort')


### PR DESCRIPTION
## Description of Changes
Just fixed a typo in a test file (run-tests.sh)
(*for a change this small in a non python, running the below pre-merge tasks would be unecessary*)

## Major Changes Implemented:
-  

## Pre-Merge Tasks
- [ ] Formatted all modified files w/ `python-black`
- [ ] Sorted imports for modified files w/ `isort`
- [ ] Ran `flake8` on repo, and fixed any new problems w/ modified files
- [ ] Ran `pytest` test cases
- [ ] Added brief summary of updates to CHANGELOG (under `[Unreleased]`)



<!--
If you are submitting a pull request for a new module, the following
information is also helpful:

## Platform and Environment Restrictions
(e.g. "Windows targets without HOTFIX XXXXXX")

## Full Qualified Module Name
(e.g. "linux.enumerate.system.network")

## Artifacts Generated
(e.g. "creates file at /etc/something.ini tracked w/ a tamper")

## Tested Targets
(e.g. "Tested on Windows 10 1604")
-->
