### PR TITLE
Added Python 3.13 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and simply didn't have the time to go back and retroactively create one.
 
 ### Added
 - Added missed `PlatformError` for `upload` command (e.g. "no gtfobins writers available")
+- Addes Python 3.13 support
 
 ## [0.5.4] - 2022-01-27
 Bug fix for the `load` command.

--- a/pwncat/commands/__init__.py
+++ b/pwncat/commands/__init__.py
@@ -34,47 +34,43 @@ Example Custom Command
         def run(self, manager: "pwncat.manager.Manager", args: "argparse.Namespace"):
             manager.log("we ran a custom command!")
 """
-import os
-import re
-import sys
-import tty
-import fcntl
-import shlex
-import pkgutil
-import termios
+
 import argparse
+import fcntl
 import importlib
-from io import TextIOWrapper
+import os
+import pkgutil
+import re
+import shlex
+import sys
+import termios
+import tty
 from enum import Enum, auto
-from typing import Dict, List, Type, Callable, Iterable
 from functools import partial
+from io import TextIOWrapper
+from typing import Callable, Dict, Iterable, List, Type
 
 import rich.text
-from pygments import token
 from prompt_toolkit import ANSI, PromptSession
+from prompt_toolkit.application.current import get_app
+from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
+from prompt_toolkit.completion import (CompleteEvent, Completer, Completion,
+                                       WordCompleter, merge_completers)
+from prompt_toolkit.document import Document
+from prompt_toolkit.history import History
+from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.lexers import PygmentsLexer
+from prompt_toolkit.patch_stdout import patch_stdout
+from prompt_toolkit.styles import Style, merge_styles
+from prompt_toolkit.styles.pygments import style_from_pygments_cls
+from pygments import token
 from pygments.lexer import RegexLexer
 from pygments.styles import get_style_by_name
-from prompt_toolkit.lexers import PygmentsLexer
-from prompt_toolkit.styles import Style, merge_styles
-from prompt_toolkit.history import History
-from prompt_toolkit.document import Document
-from prompt_toolkit.completion import (
-    Completer,
-    Completion,
-    CompleteEvent,
-    WordCompleter,
-    merge_completers,
-)
-from prompt_toolkit.key_binding import KeyBindings
-from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
-from prompt_toolkit.patch_stdout import patch_stdout
-from prompt_toolkit.styles.pygments import style_from_pygments_cls
-from prompt_toolkit.application.current import get_app
 
 import pwncat
 import pwncat.db
-from pwncat.util import console
 from pwncat.channel import ChannelClosed
+from pwncat.util import console
 
 
 class Complete(Enum):
@@ -446,7 +442,6 @@ class CommandParser:
         # Saved terminal state to support switching between raw and normal mode.
         self.saved_term_state = None
 
-
     def setup_prompt(self):
         """This needs to happen after __init__ when the database is fully
         initialized."""
@@ -787,7 +782,8 @@ class CommandParser:
 
 class CommandLexer(RegexLexer):
     """Implements a Regular Expression based pygments lexer for dynamically highlighting
-    the pwncat prompt during typing. The tokens are generated from command definitions."""
+    the pwncat prompt during typing. The tokens are generated from command definitions.
+    """
 
     tokens = {}
 

--- a/pwncat/commands/__init__.py
+++ b/pwncat/commands/__init__.py
@@ -43,6 +43,7 @@ import shlex
 import pkgutil
 import termios
 import argparse
+import importlib
 from io import TextIOWrapper
 from enum import Enum, auto
 from typing import Dict, List, Type, Callable, Iterable
@@ -432,11 +433,9 @@ class CommandParser:
         for loader, module_name, is_pkg in pkgutil.walk_packages(__path__):
             if module_name == "base":
                 continue
-            self.commands.append(
-                loader.find_module(module_name)
-                .load_module(module_name)
-                .Command(manager)
-            )
+            full_module_name = f"{__name__}.{module_name}"
+            module = importlib.import_module(full_module_name)
+            self.commands.append(module.Command(manager))
 
         self.prompt: PromptSession = None
         self.toolbar: PromptSession = None
@@ -444,9 +443,9 @@ class CommandParser:
         self.aliases: Dict[str, CommandDefinition] = {}
         self.shortcuts: Dict[str, CommandDefinition] = {}
         self.found_prefix: bool = False
-        # Saved terminal state to support switching between raw and normal
-        # mode.
+        # Saved terminal state to support switching between raw and normal mode.
         self.saved_term_state = None
+
 
     def setup_prompt(self):
         """This needs to happen after __init__ when the database is fully


### PR DESCRIPTION
## Description of Changes

Fixes https://github.com/calebstewart/pwncat/issues/294.

**Please note any `noqa:` comments needed to appease flake8.**

## Major Changes Implemented:
- Added Python 3.13 support

In Python 3.13, `loader.find_module()` no longer exists, which causes the `AttributeError` so it has been replaced by `importlib`.

## Pre-Merge Tasks
- [X] Formatted all modified files w/ `python-black`
- [X] Sorted imports for modified files w/ `isort`
- [ ] Ran `flake8` on repo, and fixed any new problems w/ modified files
- [ ] Ran `pytest` test cases
- [X] Added brief summary of updates to CHANGELOG (under `[Unreleased]`)

**For issues with pre-merge tasks, see CONTRIBUTING.md**

<!--
If you are submitting a pull request for a new module, the following
information is also helpful:

## Platform and Environment Restrictions
(e.g. "Windows targets without HOTFIX XXXXXX")

## Full Qualified Module Name
(e.g. "linux.enumerate.system.network")

## Artifacts Generated
(e.g. "creates file at /etc/something.ini tracked w/ a tamper")

## Tested Targets
(e.g. "Tested on Windows 10 1604")
-->
